### PR TITLE
update analyser to not throw an error when running into non compliant resources

### DIFF
--- a/openapi/api_spec_analyser_test.go
+++ b/openapi/api_spec_analyser_test.go
@@ -26,7 +26,7 @@ func TestResourceInstanceRegex(t *testing.T) {
 func TestResourceInstanceEndPoint(t *testing.T) {
 	Convey("Given an apiSpecAnalyser", t, func() {
 		a := apiSpecAnalyser{}
-		Convey("When resourceInstanceRegex method is called with a valid resource path such as '/resource/{id}'", func() {
+		Convey("When isResourceInstanceEndPoint method is called with a valid resource path such as '/resource/{id}'", func() {
 			resourceInstance, err := a.isResourceInstanceEndPoint("/resource/{id}")
 			Convey("Then the error returned should be nil", func() {
 				So(err, ShouldBeNil)
@@ -35,7 +35,25 @@ func TestResourceInstanceEndPoint(t *testing.T) {
 				So(resourceInstance, ShouldBeTrue)
 			})
 		})
-		Convey("When resourceInstanceRegex method is called with an invalid resource path such as '/resource/not/instance/path' not conforming with the expected pattern '/resource/{id}'", func() {
+		Convey("When isResourceInstanceEndPoint method is called with a long path such as '/very/long/path/{id}'", func() {
+			resourceInstance, err := a.isResourceInstanceEndPoint("/very/long/path/{id}")
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the value returned should be true", func() {
+				So(resourceInstance, ShouldBeTrue)
+			})
+		})
+		Convey("When isResourceInstanceEndPoint method is called with a path that has path parameters '/resource/{name}/subresource/{id}'", func() {
+			resourceInstance, err := a.isResourceInstanceEndPoint("/resource/{name}/subresource/{id}")
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the value returned should be true", func() {
+				So(resourceInstance, ShouldBeTrue)
+			})
+		})
+		Convey("When isResourceInstanceEndPoint method is called with an invalid resource path such as '/resource/not/instance/path' not conforming with the expected pattern '/resource/{id}'", func() {
 			resourceInstance, err := a.isResourceInstanceEndPoint("/resource/not/valid/instance/path")
 			Convey("Then the error returned should be nil", func() {
 				So(err, ShouldBeNil)
@@ -47,15 +65,372 @@ func TestResourceInstanceEndPoint(t *testing.T) {
 	})
 }
 
-func TestFindMatchingRootPath(t *testing.T) {
+func TestGetPayloadDefName(t *testing.T) {
 	Convey("Given an apiSpecAnalyser", t, func() {
 		a := apiSpecAnalyser{}
-		Convey("When findMatchingResourceRoot method is called with a valid resource path such as '/users/{id}' and paths containing that path with trailing slash", func() {
-			paths := map[string]spec.PathItem{}
-			pathItem := spec.PathItem{}
-			pathItem.Post = &spec.Operation{}
-			paths["/users/"] = pathItem
-			resourceRootPath, _, err := a.findMatchingResourceRoot("/users/{id}", paths)
+
+		// Local Reference use cases
+		Convey("When getPayloadDefName method is called with a valid internal definition path", func() {
+			defName, err := a.getPayloadDefName("#/definitions/ContentDeliveryNetworkV1")
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the value returned should be true", func() {
+				So(defName, ShouldEqual, "ContentDeliveryNetworkV1")
+			})
+		})
+
+		Convey("When getPayloadDefName method is called with a URL (not supported)", func() {
+			_, err := a.getPayloadDefName("http://path/to/your/resource.json#myElement")
+			Convey("Then the error returned should not be nil", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+
+		// Remote Reference use cases
+		Convey("When getPayloadDefName method is called with an element of the document located on the same server (not supported)", func() {
+			_, err := a.getPayloadDefName("document.json#/myElement")
+			Convey("Then the error returned should not be nil", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When getPayloadDefName method is called with an element of the document located in the parent folder (not supported)", func() {
+			_, err := a.getPayloadDefName("../document.json#/myElement")
+			Convey("Then the error returned should not be nil", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When getPayloadDefName method is called with an specific element of the document stored on the different server (not supported)", func() {
+			_, err := a.getPayloadDefName("http://path/to/your/resource.json#myElement")
+			Convey("Then the error returned should not be nil", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+
+		// URL Reference use case
+		Convey("When getPayloadDefName method is called with an element of the document located in another folder (not supported)", func() {
+			_, err := a.getPayloadDefName("../another-folder/document.json#/myElement")
+			Convey("Then the error returned should not be nil", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When getPayloadDefName method is called with document on the different server, which uses the same protocol (not supported)", func() {
+			_, err := a.getPayloadDefName("//anotherserver.com/files/example.json")
+			Convey("Then the error returned should not be nil", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+}
+
+func TestGetResourcePayloadSchemaRef(t *testing.T) {
+	Convey("Given an apiSpecAnalyser", t, func() {
+		a := apiSpecAnalyser{}
+
+		Convey("When getResourcePayloadSchemaRef method is called with an operation that has a reference to the resource schema definition", func() {
+			expectedRef := "#/definitions/ContentDeliveryNetworkV1"
+			ref := spec.MustCreateRef(expectedRef)
+			operation := &spec.Operation{
+				OperationProps: spec.OperationProps{
+					Parameters: []spec.Parameter{
+						{
+							ParamProps: spec.ParamProps{
+								In:   "body",
+								Name: "body",
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			returnedRef, err := a.getResourcePayloadSchemaRef(operation)
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(returnedRef, ShouldEqual, expectedRef)
+			})
+		})
+
+		Convey("When getResourcePayloadSchemaRef method is called with an operation that does not have parameters", func() {
+			operation := &spec.Operation{
+				OperationProps: spec.OperationProps{
+					Parameters: []spec.Parameter{},
+				},
+			}
+			_, err := a.getResourcePayloadSchemaRef(operation)
+			Convey("Then the error returned should not be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "operation does not have parameters defined")
+			})
+		})
+		Convey("When getResourcePayloadSchemaRef method is called with an operation that is missing required body parameter ", func() {
+			operation := &spec.Operation{
+				OperationProps: spec.OperationProps{
+					Parameters: []spec.Parameter{
+						{
+							ParamProps: spec.ParamProps{
+								In:   "header",
+								Name: "some-header",
+							},
+						},
+					},
+				},
+			}
+			_, err := a.getResourcePayloadSchemaRef(operation)
+			Convey("Then the error returned should not be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "operation is missing required 'body' type parameter")
+			})
+		})
+		Convey("When getResourcePayloadSchemaRef method is called with an operation that has multiple body parameters", func() {
+			operation := &spec.Operation{
+				OperationProps: spec.OperationProps{
+					Parameters: []spec.Parameter{
+						{
+							ParamProps: spec.ParamProps{
+								In:   "body",
+								Name: "first body",
+							},
+						},
+						{
+							ParamProps: spec.ParamProps{
+								In:   "body",
+								Name: "second body",
+							},
+						},
+					},
+				},
+			}
+			_, err := a.getResourcePayloadSchemaRef(operation)
+			Convey("Then the error returned should not be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "operation contains multiple 'body' parameters")
+			})
+		})
+		Convey("When getResourcePayloadSchemaRef method is called with an operation that is missing a the schema field", func() {
+			operation := &spec.Operation{
+				OperationProps: spec.OperationProps{
+					Parameters: []spec.Parameter{
+						{
+							ParamProps: spec.ParamProps{
+								In:   "body",
+								Name: "body",
+								//Schema: No schema
+							},
+						},
+					},
+				},
+			}
+			_, err := a.getResourcePayloadSchemaRef(operation)
+			Convey("Then the error returned should not be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "operation is missing the ref to the schema definition")
+			})
+		})
+		Convey("When getResourcePayloadSchemaRef method is called with an operation that has a schema but the ref is not populated", func() {
+			operation := &spec.Operation{
+				OperationProps: spec.OperationProps{
+					Parameters: []spec.Parameter{
+						{
+							ParamProps: spec.ParamProps{
+								In:     "body",
+								Name:   "body",
+								Schema: &spec.Schema{},
+							},
+						},
+					},
+				},
+			}
+			_, err := a.getResourcePayloadSchemaRef(operation)
+			Convey("Then the error returned should not be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "operation has an invalid schema definition ref empty")
+			})
+		})
+	})
+}
+
+func TestGetResourcePayloadSchemaDef(t *testing.T) {
+	Convey("Given an apiSpecAnalyser", t, func() {
+		swaggerContent := `swagger: "2.0"
+definitions:
+  Users:
+    type: "object"
+    required:
+      - name
+    properties:
+      id:
+        type: "string"
+        readOnly: true`
+
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When getResourcePayloadSchemaDef method is called with an operation containing a valid ref: '#/definitions/Users'", func() {
+			expectedRef := "#/definitions/Users"
+			ref := spec.MustCreateRef(expectedRef)
+			operation := &spec.Operation{
+				OperationProps: spec.OperationProps{
+					Parameters: []spec.Parameter{
+						{
+							ParamProps: spec.ParamProps{
+								In:   "body",
+								Name: "body",
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			resourcePayloadSchemaDef, err := a.getResourcePayloadSchemaDef(operation)
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("Then the value returned should be a valid schema def", func() {
+				So(len(resourcePayloadSchemaDef.Type), ShouldEqual, 1)
+				So(resourcePayloadSchemaDef.Type, ShouldContain, "object")
+			})
+		})
+
+	})
+
+	Convey("Given an apiSpecAnalyser", t, func() {
+		a := apiSpecAnalyser{}
+		Convey("When getResourcePayloadSchemaDef method is called with an operation that is missing the parameters section", func() {
+			operation := &spec.Operation{
+				OperationProps: spec.OperationProps{},
+			}
+			_, err := a.getResourcePayloadSchemaDef(operation)
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "operation does not have parameters defined")
+			})
+		})
+	})
+
+	Convey("Given an apiSpecAnalyser", t, func() {
+		swaggerContent := `swagger: "2.0"
+definitions:
+  OtherDef:
+    type: "object"
+    required:
+      - name
+    properties:
+      id:
+        type: "string"
+        readOnly: true`
+
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When getResourcePayloadSchemaDef method is called with an operation that is missing the definition the ref is pointing at", func() {
+			ref := spec.MustCreateRef("#/definitions/Users")
+			operation := &spec.Operation{
+				OperationProps: spec.OperationProps{
+					Parameters: []spec.Parameter{
+						{
+							ParamProps: spec.ParamProps{
+								In:   "body",
+								Name: "body",
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			_, err := a.getResourcePayloadSchemaDef(operation)
+			Convey("Then the error returned should NOT be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "missing schema definition in the swagger file with the supplied ref '#/definitions/Users'")
+			})
+		})
+	})
+}
+
+func TestFindMatchingResourceRootPath(t *testing.T) {
+
+	Convey("Given an apiSpecAnalyser with a valid resource path such as '/users/{id}' and missing resource root path", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The cdn id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When findMatchingResourceRootPath method is called ", func() {
+			_, err := a.findMatchingResourceRootPath("/users/{id}")
+			Convey("Then the error returned should not be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "resource instance path '/users/{id}' missing resource root path")
+			})
+		})
+	})
+
+	Convey("Given an apiSpecAnalyser with a valid resource path such as '/users/{id}' and root path with trailing slash", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users/:
+    post:
+      parameters:
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/Users"
+      responses:
+        201:
+          schema:
+            $ref: "#/definitions/Users"
+  /users/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The cdn id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When findMatchingResourceRootPath method is called ", func() {
+			resourceRootPath, err := a.findMatchingResourceRootPath("/users/{id}")
 			Convey("Then the error returned should be nil", func() {
 				So(err, ShouldBeNil)
 			})
@@ -63,12 +438,37 @@ func TestFindMatchingRootPath(t *testing.T) {
 				So(resourceRootPath, ShouldEqual, "/users/")
 			})
 		})
-		Convey("When findMatchingResourceRoot method is called with a valid resource path such as '/users/{id}' and paths containing that path without a trailing slash", func() {
-			paths := map[string]spec.PathItem{}
-			pathItem := spec.PathItem{}
-			pathItem.Post = &spec.Operation{}
-			paths["/users"] = pathItem
-			resourceRootPath, _, err := a.findMatchingResourceRoot("/users/{id}", paths)
+	})
+
+	Convey("Given an apiSpecAnalyser with a valid resource path such as '/users/{id}' and root path with without slash", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users:
+    post:
+      parameters:
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/Users"
+      responses:
+        201:
+          schema:
+            $ref: "#/definitions/Users"
+  /users/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The cdn id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When findMatchingResourceRootPath method is called ", func() {
+			resourceRootPath, err := a.findMatchingResourceRootPath("/users/{id}")
 			Convey("Then the error returned should be nil", func() {
 				So(err, ShouldBeNil)
 			})
@@ -76,12 +476,37 @@ func TestFindMatchingRootPath(t *testing.T) {
 				So(resourceRootPath, ShouldEqual, "/users")
 			})
 		})
-		Convey("When findMatchingResourceRoot method is called with a valid resource path that is versioned such as '/v1/users/{id}' and paths containing that resource with version", func() {
-			paths := map[string]spec.PathItem{}
-			pathItem := spec.PathItem{}
-			pathItem.Post = &spec.Operation{}
-			paths["/v1/users"] = pathItem
-			resourceRootPath, _, err := a.findMatchingResourceRoot("/v1/users/{id}", paths)
+	})
+
+	Convey("Given an apiSpecAnalyser with a valid resource path that is versioned such as '/v1/users/{id}' and root path containing version", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /v1/users:
+    post:
+      parameters:
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/Users"
+      responses:
+        201:
+          schema:
+            $ref: "#/definitions/Users"
+  /v1/users/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The cdn id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When findMatchingResourceRootPath method is called ", func() {
+			resourceRootPath, err := a.findMatchingResourceRootPath("/v1/users/{id}")
 			Convey("Then the error returned should be nil", func() {
 				So(err, ShouldBeNil)
 			})
@@ -89,17 +514,8 @@ func TestFindMatchingRootPath(t *testing.T) {
 				So(resourceRootPath, ShouldEqual, "/v1/users")
 			})
 		})
-		Convey("When findMatchingResourceRoot method is called with an invalid resource path such as '/resource/not/instance/path'", func() {
-			paths := map[string]spec.PathItem{}
-			resourceRootPath, _, err := a.findMatchingResourceRoot("/resource/not/instance/path", paths) // instnace paths are of form */{id}
-			Convey("Then the error returned should be nil", func() {
-				So(err, ShouldBeNil)
-			})
-			Convey("And the value returned should be empty", func() {
-				So(resourceRootPath, ShouldBeEmpty)
-			})
-		})
 	})
+
 }
 
 func TestGetResourceName(t *testing.T) {
@@ -116,7 +532,7 @@ func TestGetResourceName(t *testing.T) {
 		})
 
 		Convey("When getResourceName method is called with an invalid resource instance path such as '/resource/not/instance/path'", func() {
-			_, err := a.getResourceName("'/resource/not/instance/path'")
+			_, err := a.getResourceName("/resource/not/instance/path")
 			Convey("Then the error returned should not be nil", func() {
 				So(err, ShouldNotBeNil)
 			})
@@ -132,7 +548,7 @@ func TestGetResourceName(t *testing.T) {
 			})
 		})
 
-		Convey("When getResourceName method is called with a valid resource instance path that is versioned but long such as '/v1/something/users/{id}'", func() {
+		Convey("When getResourceName method is called with a valid resource instance long path that is versioned such as '/v1/something/users/{id}'", func() {
 			resourceName, err := a.getResourceName("/v1/something/users/{id}")
 			Convey("Then the error returned should be nil", func() {
 				So(err, ShouldBeNil)
@@ -141,33 +557,64 @@ func TestGetResourceName(t *testing.T) {
 				So(resourceName, ShouldEqual, "users_v1")
 			})
 		})
+
+		Convey("When getResourceName method is called with resource instance which has path parameters '/api/v1/nodes/{name}/proxy/{path}'", func() {
+			resourceName, err := a.getResourceName("/api/v1/nodes/{name}/proxy/{path}")
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the value returned should still be 'proxy_v1'", func() {
+				So(resourceName, ShouldEqual, "proxy_v1")
+			})
+		})
 	})
 }
 
 func TestPostIsPresent(t *testing.T) {
-	Convey("Given an apiSpecAnalyser", t, func() {
-		a := apiSpecAnalyser{}
-		Convey("When postIsPresent method is called with a path '/users' that has a post operation'", func() {
-			paths := map[string]spec.PathItem{
-				"/users": {
-					PathItemProps: spec.PathItemProps{
-						Post: &spec.Operation{},
-					},
-				},
-			}
-			postIsPresent := a.postIsPresent("/users", paths)
+
+	Convey("Given an apiSpecAnalyser with a path '/users' that has a post operation", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users:
+    post:
+      parameters:
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/Users"
+      responses:
+        201:
+          schema:
+            $ref: "#/definitions/Users"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When postDefined method is called'", func() {
+			postIsPresent := a.postDefined("/users")
 			Convey("Then the value returned should be true", func() {
 				So(postIsPresent, ShouldBeTrue)
 			})
 		})
+	})
 
-		Convey("When postIsPresent method is called with a path '/users' that DOES NOT have a post operation'", func() {
-			paths := map[string]spec.PathItem{
-				"/users": {
-					PathItemProps: spec.PathItemProps{},
-				},
-			}
-			postIsPresent := a.postIsPresent("/users", paths)
+	Convey("Given an apiSpecAnalyser with a path '/users' that DOES NOT have a post operation", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users:`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When postDefined method is called'", func() {
+			postIsPresent := a.postDefined("/users")
+			Convey("Then the value returned should be false", func() {
+				So(postIsPresent, ShouldBeFalse)
+			})
+		})
+	})
+
+	Convey("Given an apiSpecAnalyser with a path '/users'", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users:`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When postDefined method is called wigh a non existing path'", func() {
+			postIsPresent := a.postDefined("/nonExistingPath")
 			Convey("Then the value returned should be false", func() {
 				So(postIsPresent, ShouldBeFalse)
 			})
@@ -175,278 +622,578 @@ func TestPostIsPresent(t *testing.T) {
 	})
 }
 
-func TestIsEndPointTerraformResourceCompliant(t *testing.T) {
+func TestValidateResourceSchemaDefinition(t *testing.T) {
 	Convey("Given an apiSpecAnalyser", t, func() {
 		a := apiSpecAnalyser{}
-		// This use case covers the bare minimum operations (GET/POST) that a resource has to expose to be considered a terraform resource
-		Convey("When TestIsEndPointTerraformResourceCompliant method is called with an resource instance path such as '/users/{id}' that has a GET operation and the corresponding resource root path '/users' exposes a POST operation", func() {
-			paths := map[string]spec.PathItem{
-				"/users": {
-					PathItemProps: spec.PathItemProps{
-						Post: &spec.Operation{},
-					},
-				},
-				"/users/{id}": {
-					PathItemProps: spec.PathItemProps{
-						Get: &spec.Operation{},
+		Convey("When validateResourceSchemaDefinition method is called with a valid schema definition containing a property ID'", func() {
+			schema := &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Properties: map[string]spec.Schema{
+						"id": spec.Schema{},
 					},
 				},
 			}
-			isEndPointTerraformResourceCompliant, err := a.isEndPointTerraformResourceCompliant("/users/{id}", paths)
-			Convey("Then the error returned should be nil", func() {
+			err := a.validateResourceSchemaDefinition(schema)
+			Convey("Then error returned should be nil", func() {
 				So(err, ShouldBeNil)
-			})
-			Convey("And the value returned should be true", func() {
-				So(isEndPointTerraformResourceCompliant, ShouldBeTrue)
 			})
 		})
-
-		// This is the ideal case where the resource exposes al CRUD operations
-		Convey("When TestIsEndPointTerraformResourceCompliant method is called with an resource instance path such as '/users/{id}' that has a GET/PUT/DELETE operations exposed and the corresponding resource root path '/users' exposes a POST operation", func() {
-			paths := map[string]spec.PathItem{
-				"/users": {
-					PathItemProps: spec.PathItemProps{
-						Post: &spec.Operation{},
-					},
-				},
-				"/users/{id}": {
-					PathItemProps: spec.PathItemProps{
-						Get:    &spec.Operation{},
-						Delete: &spec.Operation{},
-						Put:    &spec.Operation{},
+		Convey("When validateResourceSchemaDefinition method is called with a valid schema definition missing an ID property but a different property acts as unique identifier'", func() {
+			schema := &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Properties: map[string]spec.Schema{
+						"name": spec.Schema{
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									extTfID: true,
+								},
+							},
+						},
 					},
 				},
 			}
-			isEndPointTerraformResourceCompliant, err := a.isEndPointTerraformResourceCompliant("/users/{id}", paths)
-			Convey("Then the error returned should be nil", func() {
+			err := a.validateResourceSchemaDefinition(schema)
+			Convey("Then error returned should be nil", func() {
 				So(err, ShouldBeNil)
-			})
-			Convey("And the value returned should be true", func() {
-				So(isEndPointTerraformResourceCompliant, ShouldBeTrue)
 			})
 		})
-
-		// This use case avoids resource duplicates as the root paths are filtered out
-		Convey("When TestIsEndPointTerraformResourceCompliant method is called with a non resource instance path such as '/users'", func() {
-			paths := map[string]spec.PathItem{
-				"/users": {
-					PathItemProps: spec.PathItemProps{
-						Post: &spec.Operation{},
-					},
-				},
-				"/users/{id}": {
-					PathItemProps: spec.PathItemProps{
-						Get: &spec.Operation{},
+		Convey("When validateResourceSchemaDefinition method is called with a valid schema definition with both a property that name 'id' and a different property with the 'x-terraform-id' extension'", func() {
+			schema := &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Properties: map[string]spec.Schema{
+						"id": spec.Schema{},
+						"name": spec.Schema{
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									extTfID: true,
+								},
+							},
+						},
 					},
 				},
 			}
-			isEndPointTerraformResourceCompliant, err := a.isEndPointTerraformResourceCompliant("/users", paths)
-			Convey("Then the error returned should be nil", func() {
+			err := a.validateResourceSchemaDefinition(schema)
+			Convey("Then error returned should be nil", func() {
 				So(err, ShouldBeNil)
-			})
-			Convey("And the value returned should be false", func() {
-				So(isEndPointTerraformResourceCompliant, ShouldBeFalse)
 			})
 		})
-
-		Convey("When TestIsEndPointTerraformResourceCompliant method is called with a resource instance path such as '/monitors/{id}' that DOES NOT expose a GET operation", func() {
-			paths := map[string]spec.PathItem{
-				"/monitors": {
-					PathItemProps: spec.PathItemProps{
-						Post: &spec.Operation{},
-					},
-				},
-				"/monitors/{id}": {
-					PathItemProps: spec.PathItemProps{},
-				},
-			}
-			isEndPointTerraformResourceCompliant, err := a.isEndPointTerraformResourceCompliant("/monitors/{id}", paths)
-			Convey("Then the error returned should be nil", func() {
-				So(err, ShouldBeNil)
-			})
-			Convey("And the value returned should be false as a resource to be considered compliant has to expose a POST operation on the root path (in this case /monitors) and a GET operation in the instance resource path (in this case /monitors/{id})", func() {
-				So(isEndPointTerraformResourceCompliant, ShouldBeFalse)
-			})
-		})
-
-		Convey("When TestIsEndPointTerraformResourceCompliant method is called with a resource instance path such as '/monitors/{id}' that its root path '/monitors' DOES NOT expose a POST operation", func() {
-			paths := map[string]spec.PathItem{
-				"/monitors": {
-					PathItemProps: spec.PathItemProps{},
-				},
-				"/monitors/{id}": {
-					PathItemProps: spec.PathItemProps{
-						Get: &spec.Operation{},
+		Convey("When validateResourceSchemaDefinition method is called with a NON valid schema definition due to missing unique identifier'", func() {
+			schema := &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Properties: map[string]spec.Schema{
+						"name": spec.Schema{},
 					},
 				},
 			}
-			isEndPointTerraformResourceCompliant, err := a.isEndPointTerraformResourceCompliant("/monitors/{id}", paths)
-			Convey("Then the error returned should be nil", func() {
-				So(err, ShouldBeNil)
+			err := a.validateResourceSchemaDefinition(schema)
+			Convey("Then error returned should NOT be nil", func() {
+				So(err, ShouldNotBeNil)
 			})
-			Convey("And the value returned should be false as a resource to be considered compliant has to expose a POST operation on the root path (in this case /monitors) and a GET operation in the instance resource path (in this case /monitors/{id})", func() {
-				So(isEndPointTerraformResourceCompliant, ShouldBeFalse)
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "resource schema is missing a property that uniquely identifies the resource, either a property named 'id' or a property with the extension 'x-terraform-id' set to true")
 			})
 		})
 	})
 }
 
-func TestGetResourcePayloadSchemaDef(t *testing.T) {
-	Convey("Given an apiSpecAnalyser loaded with the following swagger", t, func() {
-		var swaggerJSON = `{
-  "swagger": "2.0",
-   "paths":{
-      "/v1/cdns":{
-         "post":{
-            "summary":"Create cdn",
-            "parameters":[
-               {
-                  "in":"body",
-                  "name":"body",
-                  "description":"Created CDN",
-                  "schema":{
-                     "$ref":"#/definitions/ContentDeliveryNetwork"
-                  }
-               }
-            ]
-         }
-      }
-   },
-  "definitions": {
-    "ContentDeliveryNetwork": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      }
-    }
-  }
-}`
-		spec, _ := loads.Analyzed(json.RawMessage([]byte(swaggerJSON)), "2.0")
-		a := apiSpecAnalyser{
-			d: spec,
-		}
+func TestValidateRootPath(t *testing.T) {
+	Convey("Given an apiSpecAnalyser with a terraform compliant root path", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users:
+    post:
+      parameters:
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/nonExisting"
+      responses:
+        201:
+          schema:
+            $ref: "#/definitions/Users"
+  /users/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The cdn id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When validateResourceSchemaDefinition method is called with '/users/{id}'", func() {
+			_, _, _, err := a.validateRootPath("/users/{id}")
+			Convey("Then the error returned should NOT be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "resource root path '/users' POST operation validation error: missing schema definition in the swagger file with the supplied ref '#/definitions/nonExisting'")
+			})
+		})
+	})
 
-		Convey("When getResourcePayloadSchemaDef method is called with a root path '/v1/cdns' containing a valid ref: '#/definitions/ContentDeliveryNetwork'", func() {
-			resourcePayloadSchemaDef, err := a.getResourcePayloadSchemaDef("/v1/cdns")
+	Convey("Given an apiSpecAnalyser with a resource instance path such as '/users/{id}' that its root path '/users' DOES NOT expose a POST operation", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users:
+    post:
+  /users/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The cdn id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When validateResourceSchemaDefinition method is called with '/users/{id}'", func() {
+			_, _, _, err := a.validateRootPath("/users/{id}")
+			Convey("Then the error returned should NOT be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "resource root path '/users' missing required POST operation")
+			})
+		})
+	})
+
+	Convey("Given an apiSpecAnalyser with a resource instance path such as '/users/{id}' that its root path '/users' is missing the reference to the schea definition", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users:
+    post:
+      parameters:
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/Users"
+      responses:
+        201:
+          schema:
+            $ref: "#/definitions/Users"
+  /users/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The cdn id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"
+definitions:
+  Users:
+    type: "object"
+    required:
+      - name
+    properties:
+      id:
+        type: "string"
+        readOnly: true
+      name:
+        type: "string"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When validateResourceSchemaDefinition method is called with '/users/{id}'", func() {
+			resourceRootPath, _, _, err := a.validateRootPath("/users/{id}")
+			Convey("Then the error returned should NOT be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(resourceRootPath, ShouldContainSubstring, "/users")
+			})
+		})
+	})
+}
+
+func TestValidateInstancePath(t *testing.T) {
+	Convey("Given an apiSpecAnalyser with a terraform compliant instance path", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The user id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When validateInstancePath method is called with '/users/{id}'", func() {
+			err := a.validateInstancePath("/users/{id}")
 			Convey("Then the error returned should be nil", func() {
 				So(err, ShouldBeNil)
 			})
-			Convey("Then the value returned should be a valid schema def", func() {
-				So(len(resourcePayloadSchemaDef.Type), ShouldEqual, 1)
-				So(resourcePayloadSchemaDef.Type, ShouldContain, "object")
-			})
 		})
+	})
 
-		Convey("When getResourcePayloadSchemaDef method is called with an unknown root path", func() {
-			_, err := a.getResourcePayloadSchemaDef("/non/existing/root/path")
-			Convey("Then the error returned should not be nil", func() {
+	Convey("Given an apiSpecAnalyser with an instance path that is missing the get operation", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users/{id}:
+    put:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The user id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When validateInstancePath method is called with '/users/{id}'", func() {
+			err := a.validateInstancePath("/users/{id}")
+			Convey("Then the error returned should NOT be nil", func() {
 				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "resource instance path '/users/{id}' missing required GET operation")
 			})
 		})
 	})
 
-	Convey("Given an apiSpecAnalyser loaded with the following swagger", t, func() {
-		var swaggerJSON = `{
-  "swagger": "2.0",
-   "paths":{
-      "/v1/cdns":{
-      }
-   }
-}`
-		spec, _ := loads.Analyzed(json.RawMessage([]byte(swaggerJSON)), "2.0")
-		a := apiSpecAnalyser{
-			d: spec,
-		}
+	Convey("Given an apiSpecAnalyser", t, func() {
+		a := apiSpecAnalyser{}
+		Convey("When validateInstancePath method is called with a non instance path", func() {
+			err := a.validateInstancePath("/users")
+			Convey("Then the error returned should NOT be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "path '/users' is not a resource instance path")
+			})
+		})
+	})
+}
 
-		Convey("When getResourcePayloadSchemaDef method is called with a root path '/v1/cdns' that is missing the post operation", func() {
-			_, err := a.getResourcePayloadSchemaDef("/v1/cdns")
+func TestIsEndPointTerraformResourceCompliant(t *testing.T) {
+	Convey("Given an apiSpecAnalyser with a fully terraform compliant resource Users", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users:
+    post:
+      parameters:
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/Users"
+      responses:
+        201:
+          schema:
+            $ref: "#/definitions/Users"
+  /users/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The cdn id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"
+definitions:
+  Users:
+    type: "object"
+    required:
+      - name
+    properties:
+      id:
+        type: "string"
+        readOnly: true
+      name:
+        type: "string"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When isEndPointFullyTerraformResourceCompliant method is called ", func() {
+			resourceRootPath, _, _, err := a.isEndPointFullyTerraformResourceCompliant("/users/{id}")
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the value returned should be", func() {
+				So(resourceRootPath, ShouldEqual, "/users")
+			})
+		})
+	})
+
+	// This is the ideal case where the resource exposes al CRUD operations
+	Convey("Given an apiSpecAnalyser with an resource instance path such as '/users/{id}' that has a GET/PUT/DELETE operations exposed and the corresponding resource root path '/users' exposes a POST operation", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users:
+    post:
+      parameters:
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/Users"
+      responses:
+        201:
+          schema:
+            $ref: "#/definitions/Users"
+  /users/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The cdn id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"
+    put:
+      parameters:
+      - name: "id"
+        in: "path"
+        type: "string"
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/Users"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Users"
+    delete:
+      parameters:
+      - name: "id"
+        in: "path"
+        type: "string"
+      responses:
+        204:
+          description: "successful operation, no content is returned"
+definitions:
+  Users:
+    type: "object"
+    required:
+      - name
+    properties:
+      id:
+        type: "string"
+        readOnly: true
+      name:
+        type: "string"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When isEndPointFullyTerraformResourceCompliant method is called ", func() {
+			resourceRootPath, _, _, err := a.isEndPointFullyTerraformResourceCompliant("/users/{id}")
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the value returned should be", func() {
+				So(resourceRootPath, ShouldEqual, "/users")
+			})
+		})
+	})
+
+	// This use case avoids resource duplicates as the root paths are filtered out
+	Convey("Given an apiSpecAnalyser", t, func() {
+		swaggerContent := `swagger: "2.0"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When isEndPointFullyTerraformResourceCompliant method is called with a non resource instance path such as '/users'", func() {
+			_, _, _, err := a.isEndPointFullyTerraformResourceCompliant("/users")
 			Convey("Then the error returned should be nil", func() {
 				So(err, ShouldNotBeNil)
 			})
-		})
-	})
-
-	Convey("Given an apiSpecAnalyser loaded with the following swagger", t, func() {
-		var swaggerJSON = `{
-  "swagger": "2.0",
-   "paths":{
-      "/v1/cdns":{
-         "post":{
-            "summary":"Create cdn"
-         }
-      }
-   }
-}`
-		spec, _ := loads.Analyzed(json.RawMessage([]byte(swaggerJSON)), "2.0")
-		a := apiSpecAnalyser{
-			d: spec,
-		}
-
-		Convey("When getResourcePayloadSchemaDef method is called with a root path '/v1/cdns' that is missing the parameters section", func() {
-			_, err := a.getResourcePayloadSchemaDef("/v1/cdns")
-			Convey("Then the error returned should be nil", func() {
-				So(err, ShouldNotBeNil)
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "path '/users' is not a resource instance path")
 			})
 		})
 	})
+
+	Convey("Given an apiSpecAnalyser with a resource that fails the instance path validation (no get operation defined)", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users/{id}:
+    put:
+    delete:`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When isEndPointFullyTerraformResourceCompliant method is called ", func() {
+			_, _, _, err := a.isEndPointFullyTerraformResourceCompliant("/users/{id}")
+			Convey("Then the error returned should NOT be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "resource instance path '/users/{id}' missing required GET operation")
+			})
+		})
+	})
+
+	Convey("Given an apiSpecAnalyser with a resource that fails the root path validation (no post operation defined)", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users:
+    post:
+  /users/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The cdn id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When isEndPointFullyTerraformResourceCompliant method is called ", func() {
+			_, _, _, err := a.isEndPointFullyTerraformResourceCompliant("/users/{id}")
+			Convey("Then the error returned should NOT be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "resource root path '/users' missing required POST operation")
+			})
+		})
+	})
+
+	Convey("Given an apiSpecAnalyser with a resource that fails the schema validation (non existing ref)", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /users:
+    post:
+      parameters:
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/Users"
+      responses:
+        201:
+          schema:
+            $ref: "#/definitions/NonExistingDefinition"
+  /users/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The cdn id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/Users"`
+		a := initAPISpecAnalyser(swaggerContent)
+		Convey("When isEndPointFullyTerraformResourceCompliant method is called ", func() {
+			_, _, _, err := a.isEndPointFullyTerraformResourceCompliant("/users/{id}")
+			Convey("Then the error returned should NOT be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the error message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "resource root path '/users' POST operation validation error: missing schema definition in the swagger file with the supplied ref '#/definitions/Users'")
+			})
+		})
+	})
+
 }
 
 func TestGetResourcesInfo(t *testing.T) {
-	Convey("Given an apiSpecAnalyser loaded with a swagger file containing a compliant terraform resource /v1/cdns", t, func() {
-		var swaggerJSON = `
-{
-   "swagger":"2.0",
-   "paths":{
-      "/v1/cdns":{
-         "post":{
-            "summary":"Create cdn",
-            "parameters":[
-               {
-                  "in":"body",
-                  "name":"body",
-                  "description":"Created CDN",
-                  "schema":{
-                     "$ref":"#/definitions/ContentDeliveryNetwork"
-                  }
-               }
-            ]
-         }
-      },
-      "/v1/cdns/{id}":{
-         "get":{
-            "summary":"Get cdn by id"
-         },
-         "put":{
-            "summary":"Updated cdn"
-         },
-         "delete":{
-            "summary":"Delete cdn"
-         }
-      }
-   },
-   "definitions":{
-      "ContentDeliveryNetwork":{
-         "type":"object",
-         "properties":{
-            "id":{
-               "type":"string"
-            }
-         }
-      }
-   }
-}`
-		spec, _ := loads.Analyzed(json.RawMessage([]byte(swaggerJSON)), "2.0")
-		a := apiSpecAnalyser{
-			d: spec,
-		}
+	Convey("Given an apiSpecAnalyser loaded with a swagger file containing a compliant terraform resource /v1/cdns and some non compliant paths", t, func() {
+		swaggerContent := `swagger: "2.0"
+paths:
+  /v1/cdns:
+    post:
+      parameters:
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/ContentDeliveryNetwork"
+      responses:
+        201:
+          schema:
+            $ref: "#/definitions/ContentDeliveryNetwork"
+  /v1/cdns/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "The cdn id that needs to be fetched."
+        required: true
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/ContentDeliveryNetwork"
+    put:
+      parameters:
+      - name: "id"
+        in: "path"
+        type: "string"
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/ContentDeliveryNetwork"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ContentDeliveryNetwork"
+    delete:
+      parameters:
+      - name: "id"
+        in: "path"
+        type: "string"
+      responses:
+        204:
+          description: "successful operation, no content is returned"
+  /non/compliant:
+    post: # this path post operation is missing a reference to the schema definition (commented out)
+      parameters: 
+      - in: "body"
+        name: "body"
+      #  schema:
+      #    $ref: "#/definitions/NonCompliant"
+      responses:
+        201:
+          schema:
+            $ref: "#/definitions/NonCompliant"
+  /non/compliant/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        type: "string"
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/NonCompliant"
+definitions:
+  ContentDeliveryNetwork:
+    type: "object"
+    properties:
+      id:
+        type: "string"
+        readOnly: true
+  NonCompliant:
+    type: "object"
+    properties:
+      id:
+        type: "string"
+        readOnly: true`
+		a := initAPISpecAnalyser(swaggerContent)
 		Convey("When getResourcesInfo method is called ", func() {
 			resourcesInfo, err := a.getResourcesInfo()
 			Convey("Then the error returned should be nil", func() {
 				So(err, ShouldBeNil)
 			})
-			Convey("And the resources info map should contain a resource called cdns_v1", func() {
+			Convey("And the resources info map should only contain a resource called cdns_v1", func() {
 				So(len(resourcesInfo), ShouldEqual, 1)
 				So(resourcesInfo, ShouldContainKey, "cdns_v1")
 			})
@@ -481,10 +1228,7 @@ func TestGetResourcesInfo(t *testing.T) {
       }
    }
 }`
-		spec, _ := loads.Analyzed(json.RawMessage([]byte(swaggerJSON)), "2.0")
-		a := apiSpecAnalyser{
-			d: spec,
-		}
+		a := initAPISpecAnalyser(swaggerJSON)
 		Convey("When getResourcesInfo method is called ", func() {
 			resourcesInfo, err := a.getResourcesInfo()
 			Convey("Then the error returned should be nil", func() {
@@ -492,282 +1236,6 @@ func TestGetResourcesInfo(t *testing.T) {
 			})
 			Convey("And the resources info map should contain a resource called cdns_v1", func() {
 				So(resourcesInfo, ShouldBeEmpty)
-			})
-		})
-	})
-
-	Convey("Given an apiSpecAnalyser loaded with a swagger file containing a non compliant terraform resource /v1/cdns/{id} because its missing the get operation", t, func() {
-		var swaggerJSON = `
-{
-   "swagger":"2.0",
-   "paths":{
-      "/v1/cdns":{
-         "post":{
-            "summary":"Create cdn",
-            "parameters":[
-               {
-                  "in":"body",
-                  "name":"body",
-                  "description":"Created CDN",
-                  "schema":{
-                     "$ref":"#/definitions/ContentDeliveryNetwork"
-                  }
-               }
-            ]
-         }
-      },
-      "/v1/cdns/{id}":{
-         "put":{
-            "summary":"Updated cdn"
-         },
-         "delete":{
-            "summary":"Delete cdn"
-         }
-      }
-   },
-   "definitions":{
-      "ContentDeliveryNetwork":{
-         "type":"object",
-         "properties":{
-            "id":{
-               "type":"string"
-            }
-         }
-      }
-   }
-}`
-		spec, _ := loads.Analyzed(json.RawMessage([]byte(swaggerJSON)), "2.0")
-		a := apiSpecAnalyser{
-			d: spec,
-		}
-		Convey("When getResourcesInfo method is called ", func() {
-			resourcesInfo, err := a.getResourcesInfo()
-			Convey("Then the error returned should be nil", func() {
-				So(err, ShouldBeNil)
-			})
-			Convey("And the resources info map should contain a resource called cdns_v1", func() {
-				So(resourcesInfo, ShouldBeEmpty)
-			})
-		})
-	})
-
-	Convey("Given an apiSpecAnalyser loaded with a swagger file containing a potential compliant terraform resource but the payload schema definition is missing", t, func() {
-		var swaggerJSON = `
-{
-   "swagger":"2.0",
-   "paths":{
-      "/v1/cdns":{
-         "post":{
-            "summary":"Create cdn",
-            "parameters":[
-               {
-                  "in":"body",
-                  "name":"body",
-                  "description":"Created CDN",
-                  "schema":{
-                     "$ref":"#/definitions/ContentDeliveryNetwork"
-                  }
-               }
-            ]
-         }
-      },
-      "/v1/cdns/{id}":{
-         "get":{
-            "summary":"Get cdn by id"
-         },
-         "put":{
-            "summary":"Updated cdn"
-         },
-         "delete":{
-            "summary":"Delete cdn"
-         }
-      }
-   }
-}`
-		spec, _ := loads.Analyzed(json.RawMessage([]byte(swaggerJSON)), "2.0")
-		a := apiSpecAnalyser{
-			d: spec,
-		}
-		Convey("When getResourcesInfo method is called ", func() {
-			_, err := a.getResourcesInfo()
-			Convey("Then the error returned should not be nil", func() {
-				So(err, ShouldNotBeNil)
-			})
-		})
-	})
-
-	Convey("Given an apiSpecAnalyser loaded with a swagger file containing a potential compliant terraform resource but the POST body is missing the reference to the schema definition", t, func() {
-		var swaggerJSON = `
-{
-   "swagger":"2.0",
-   "paths":{
-      "/v1/cdns":{
-         "post":{
-            "summary":"Create cdn",
-            "parameters":[
-               {
-                  "in":"body",
-                  "name":"body",
-                  "description":"Created CDN"
-               }
-            ]
-         }
-      },
-      "/v1/cdns/{id}":{
-         "get":{
-            "summary":"Get cdn by id"
-         },
-         "put":{
-            "summary":"Updated cdn"
-         },
-         "delete":{
-            "summary":"Delete cdn"
-         }
-      }
-   },
-   "definitions":{
-      "ContentDeliveryNetwork":{
-         "type":"object",
-         "properties":{
-            "id":{
-               "type":"string"
-            }
-         }
-      }
-   }
-}`
-		spec, _ := loads.Analyzed(json.RawMessage([]byte(swaggerJSON)), "2.0")
-		a := apiSpecAnalyser{
-			d: spec,
-		}
-		Convey("When getResourcesInfo method is called ", func() {
-			_, err := a.getResourcesInfo()
-			Convey("Then the error returned should not be nil", func() {
-				So(err, ShouldNotBeNil)
-			})
-		})
-	})
-
-	Convey("Given an apiSpecAnalyser loaded with a swagger file containing a compliant terraform resource that has a POST operation with multiple parameters", t, func() {
-		var swaggerJSON = `
-{
-   "swagger":"2.0",
-   "paths":{
-      "/v1/cdns":{
-         "post":{
-            "summary":"Create cdn",
-            "parameters":[
-               {
-                  "in":"body",
-                  "name":"body",
-                  "description":"Created CDN",
-                  "schema":{
-                     "$ref":"#/definitions/ContentDeliveryNetwork"
-                  }
-               },
-               {
-                  "in":"header",
-                  "name":"X-Request-ID",
-                  "type": "string",
-				  "required": true
-               }
-            ]
-         }
-      },
-      "/v1/cdns/{id}":{
-         "get":{
-            "summary":"Get cdn by id"
-         },
-         "put":{
-            "summary":"Updated cdn"
-         },
-         "delete":{
-            "summary":"Delete cdn"
-         }
-      }
-   },
-   "definitions":{
-      "ContentDeliveryNetwork":{
-         "type":"object",
-         "properties":{
-            "id":{
-               "type":"string"
-            }
-         }
-      }
-   }
-}`
-		spec, _ := loads.Analyzed(json.RawMessage([]byte(swaggerJSON)), "2.0")
-		a := apiSpecAnalyser{
-			d: spec,
-		}
-		Convey("When getResourcesInfo method is called ", func() {
-			_, err := a.getResourcesInfo()
-			Convey("Then the error returned should be nil", func() {
-				So(err, ShouldBeNil)
-			})
-		})
-	})
-
-	Convey("Given an apiSpecAnalyser loaded with a swagger file containing a potential compliant terraform resource that has a POST operation with multiple 'body' type parameters", t, func() {
-		var swaggerJSON = `
-{
-   "swagger":"2.0",
-   "paths":{
-      "/v1/cdns":{
-         "post":{
-            "summary":"Create cdn",
-            "parameters":[
-               {
-                  "in":"body",
-                  "name":"body",
-                  "description":"Created CDN",
-                  "schema":{
-                     "$ref":"#/definitions/ContentDeliveryNetwork"
-                  }
-               },
-               {
-                  "in":"body",
-                  "name":"body2",
-                  "description":"Created CDN",
-                  "schema":{
-                     "$ref":"#/definitions/ContentDeliveryNetwork"
-                  }
-               }
-            ]
-         }
-      },
-      "/v1/cdns/{id}":{
-         "get":{
-            "summary":"Get cdn by id"
-         },
-         "put":{
-            "summary":"Updated cdn"
-         },
-         "delete":{
-            "summary":"Delete cdn"
-         }
-      }
-   },
-   "definitions":{
-      "ContentDeliveryNetwork":{
-         "type":"object",
-         "properties":{
-            "id":{
-               "type":"string"
-            }
-         }
-      }
-   }
-}`
-		spec, _ := loads.Analyzed(json.RawMessage([]byte(swaggerJSON)), "2.0")
-		a := apiSpecAnalyser{
-			d: spec,
-		}
-		Convey("When getResourcesInfo method is called ", func() {
-			_, err := a.getResourcesInfo()
-			Convey("Then the error returned should NOT be nil", func() {
-				So(err, ShouldNotBeNil)
 			})
 		})
 	})
@@ -816,10 +1284,7 @@ func TestGetResourcesInfo(t *testing.T) {
       }
    }
 }`
-		spec, _ := loads.Analyzed(json.RawMessage([]byte(swaggerJSON)), "2.0")
-		a := apiSpecAnalyser{
-			d: spec,
-		}
+		a := initAPISpecAnalyser(swaggerJSON)
 		Convey("When getResourcesInfo method is called ", func() {
 			resourceInfo, err := a.getResourcesInfo()
 			Convey("Then the error returned should be nil", func() {
@@ -830,4 +1295,10 @@ func TestGetResourcesInfo(t *testing.T) {
 			})
 		})
 	})
+}
+
+func initAPISpecAnalyser(swaggerContent string) apiSpecAnalyser {
+	swagger := json.RawMessage([]byte(swaggerContent))
+	d, _ := loads.Analyzed(swagger, "2.0")
+	return apiSpecAnalyser{d}
 }


### PR DESCRIPTION
This PR fixes a bug in the apiSpecAnalyser where paths deemed non terraform compliant would throw an error and instead of ignoring those an error would be returned to the parent function causing terraform to stop the execution right away.

- updated unit test to cover more test scenarios
- updated resourceNameRegex to handle subresources too

## Proposed changes

Fixes: #46 

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [x] Bugfix (change that fixes current functionality)
- [ ] New feature (change that adds new functionality)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'make test' locally from the terraform_provider_api folder and no errors were found
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)