### PR TITLE
check errors when reading and if error is NotFound then return nil as expected

### DIFF
--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -348,6 +348,12 @@ way they desire. More details about the 'x-terraform-field-status' extension can
 pending statuses. These are:
 
   - **x-terraform-resource-poll-completed-statuses**: (type: string) Comma separated values - Defines the statuses on which the resource state will be considered 'completed'
+*Note: For DELETE operations, the expected behaviour is that when the resource has been deleted, GET requests to the deleted 
+resource would return a 404 HTTP response status code back. This means that no payload will be returned in the response, 
+and hence there won't be any status field to check against to. Therefore, the OpenAPI Terraform provider handle deletes
+target statuses in a different way not expecting the service provide to populate this extension. Behind the scenes, the 
+OpenAPI Terraform provider will handle the polling accordingly until the resource is no longer available at which point
+the resource will be considered destroyed. If the extension is present with a value, it wil be ignored in the backend.*
   - **x-terraform-resource-poll-pending-statuses**: (type: string) Comma separated values - Defines the statuses on which the resource state will be considered 'in progress'.
 Any other state returned that returned but is not part of this list will be considered as a failure and the polling mechanism
 will stop its execution accordingly.

--- a/examples/swaggercodegen/api/resources/swagger.yaml
+++ b/examples/swaggercodegen/api/resources/swagger.yaml
@@ -218,9 +218,9 @@ paths:
           $ref: "#/definitions/LBV1"
       responses:
         202: # Accepted
-          x-terraform-resource-poll-enabled: true # [type (bool)] - this flags the response as trully async. Some resources might be async too but may require manual intervention from operators to complete the creation workflow. This flag will be used by the OpenAPI Service provider to detect whether the polling mechanism should be used or not. The flags below will only be applicable if this one is present with value 'true'
-          x-terraform-resource-poll-completed-statuses: "deployed" # [type (string)] - Comma separated values with the states that will considered this resource creation done/completed
-          x-terraform-resource-poll-pending-statuses: "deploy_pending,deploy_in_progress" # [type (string)] - Comma separated values with the states that are "allowed" and will continue trying
+          x-terraform-resource-poll-enabled: true
+          x-terraform-resource-poll-completed-statuses: "deployed"
+          x-terraform-resource-poll-pending-statuses: "deploy_pending,deploy_in_progress"
           schema:
             $ref: "#/definitions/LBV1"
           description: "this operation is asynchronous, to check the status of the deployment call GET operation and check the status field returned in the payload"
@@ -242,9 +242,9 @@ paths:
       responses:
         202:
           description: "LB v1 deletion"
-          x-terraform-resource-poll-enabled: true # [type (bool)] - this flags the response as trully async. Some resources might be async too but may require manual intervention from operators to complete the creation workflow. This flag will be used by the OpenAPI Service provider to detect whether the polling mechanism should be used or not. The flags below will only be applicable if this one is present with value 'true'
-          x-terraform-resource-poll-completed-statuses: "destroyed" # [type (string)] - This value is the default value returned by the refresh function when the read call returns a 404/ This is needed since it is expected that when the resource is deleted in the API, subsequent GET API calls to the resource instance will return 404 Not Found acknowledging that the resource instance no longer exists
-          x-terraform-resource-poll-pending-statuses: "delete_pending,delete_in_progress" # [type (string)] - Comma separated values with the states that are "allowed" and will continue trying
+          x-terraform-resource-poll-enabled: true
+          #x-terraform-resource-poll-completed-statuses: "destroyed-crazy-nusts!!!" #This extension is not needed in DELETE operations. This is due to the fact that when the resource is destroyed, it is expected that http GET calls made by the polling mechanism will get a NotFound response status code back wit no payload whatsoever. And the OpenAPI Terraform provider will internally know how to handle this particular cases without this extension being present. If the extension is present with certain value, the latter will be ignored.
+          x-terraform-resource-poll-pending-statuses: "delete_pending,delete_in_progress"
         400:
           $ref: "#/responses/Unauthorized"
         404:

--- a/examples/swaggercodegen/api/resources/swagger.yaml
+++ b/examples/swaggercodegen/api/resources/swagger.yaml
@@ -243,7 +243,7 @@ paths:
         202:
           description: "LB v1 deletion"
           x-terraform-resource-poll-enabled: true
-          #x-terraform-resource-poll-completed-statuses: "destroyed-crazy-nusts!!!" #This extension is not needed in DELETE operations. This is due to the fact that when the resource is destroyed, it is expected that http GET calls made by the polling mechanism will get a NotFound response status code back wit no payload whatsoever. And the OpenAPI Terraform provider will internally know how to handle this particular cases without this extension being present. If the extension is present with certain value, the latter will be ignored.
+          #x-terraform-resource-poll-completed-statuses: "destroyed-crazy-nusts!!!" #This extension is not needed in DELETE operations and will be ignored if present. This is due to the fact that when the resource is destroyed, it is expected that http GET calls made by the polling mechanism will get a NotFound response status code back wit no payload whatsoever. And the OpenAPI Terraform provider will internally know how to handle this particular cases without this extension being present.
           x-terraform-resource-poll-pending-statuses: "delete_pending,delete_in_progress"
         400:
           $ref: "#/responses/Unauthorized"

--- a/examples/swaggercodegen/api/resources/swagger.yaml
+++ b/examples/swaggercodegen/api/resources/swagger.yaml
@@ -241,6 +241,7 @@ paths:
         type: "string"
       responses:
         202:
+          description: "LB v1 deletion"
           x-terraform-resource-poll-enabled: true # [type (bool)] - this flags the response as trully async. Some resources might be async too but may require manual intervention from operators to complete the creation workflow. This flag will be used by the OpenAPI Service provider to detect whether the polling mechanism should be used or not. The flags below will only be applicable if this one is present with value 'true'
           x-terraform-resource-poll-completed-statuses: "destroyed" # [type (string)] - This value is the default value returned by the refresh function when the read call returns a 404/ This is needed since it is expected that when the resource is deleted in the API, subsequent GET API calls to the resource instance will return 404 Not Found acknowledging that the resource instance no longer exists
           x-terraform-resource-poll-pending-statuses: "delete_pending,delete_in_progress" # [type (string)] - Comma separated values with the states that are "allowed" and will continue trying

--- a/openapi/resource_factory.go
+++ b/openapi/resource_factory.go
@@ -211,11 +211,6 @@ func (r resourceFactory) handlePollingIfConfigured(responsePayload *map[string]i
 		return nil
 	}
 
-	targetStatuses, err := r.resourceInfo.getResourcePollTargetStatuses(*response)
-	if err != nil {
-		return err
-	}
-
 	// This is a use case where payload does not contain payload data and hence status field is not available; e,g: DELETE operations
 	// The default behaviour for this case is to consider the resource as destroyed. Hence, the below code pre-populates
 	// the target extension with the expected status that the polling mechanism expects when dealing with NotFound resources (should only happen on delete operations).
@@ -226,7 +221,12 @@ func (r resourceFactory) handlePollingIfConfigured(responsePayload *map[string]i
 			log.Printf("[WARN] service provider speficied '%s': %s for a DELETE operation. This is not expected as the normal behaviour is the resource to no longer exists once the DELETE operation is completed; hence subsequent GET calls should return 404 NotFound instead", extTfResourcePollTargetStatuses, value)
 		}
 		log.Printf("[WARN] setting extension '%s' with default value '%s'", extTfResourcePollTargetStatuses, defaultDestroyStatus)
-		targetStatuses = []string{defaultDestroyStatus}
+		response.Extensions.Add(extTfResourcePollTargetStatuses, defaultDestroyStatus)
+	}
+
+	targetStatuses, err := r.resourceInfo.getResourcePollTargetStatuses(*response)
+	if err != nil {
+		return err
 	}
 
 	pendingStatuses, err := r.resourceInfo.getResourcePollPendingStatuses(*response)

--- a/openapi/resource_factory.go
+++ b/openapi/resource_factory.go
@@ -76,12 +76,11 @@ func (r resourceFactory) create(resourceLocalData *schema.ResourceData, i interf
 	}
 	log.Printf("[INFO] Resource '%s' ID: %s", r.resourceInfo.name, resourceLocalData.Id())
 
-	err = r.handlePollingIfConfigured(resourceLocalData, providerConfig, operation.Responses, res.StatusCode, schema.TimeoutCreate)
+	err = r.handlePollingIfConfigured(&responsePayload, resourceLocalData, providerConfig, operation.Responses, res.StatusCode, schema.TimeoutCreate)
 	if err != nil {
 		return fmt.Errorf("polling mechanism failed after POST %s call with response status code (%d): %s", resourceURL, res.StatusCode, err)
 	}
-
-	return r.read(resourceLocalData, i)
+	return r.updateStateWithPayloadData(responsePayload, resourceLocalData)
 }
 
 func (r resourceFactory) read(resourceLocalData *schema.ResourceData, i interface{}) error {
@@ -162,12 +161,11 @@ func (r resourceFactory) update(resourceLocalData *schema.ResourceData, i interf
 		return fmt.Errorf("UPDATE %s failed: %s", resourceIDURL, err)
 	}
 
-	err = r.handlePollingIfConfigured(resourceLocalData, providerConfig, operation.Responses, res.StatusCode, schema.TimeoutUpdate)
+	err = r.handlePollingIfConfigured(&responsePayload, resourceLocalData, providerConfig, operation.Responses, res.StatusCode, schema.TimeoutUpdate)
 	if err != nil {
 		return fmt.Errorf("polling mechanism failed after PUT %s call with response status code (%d): %s", resourceIDURL, res.StatusCode, err)
 	}
-
-	return r.read(resourceLocalData, i)
+	return r.updateStateWithPayloadData(responsePayload, resourceLocalData)
 }
 
 func (r resourceFactory) delete(resourceLocalData *schema.ResourceData, i interface{}) error {
@@ -195,7 +193,7 @@ func (r resourceFactory) delete(resourceLocalData *schema.ResourceData, i interf
 		return fmt.Errorf("DELETE %s failed: %s", resourceIDURL, err)
 	}
 
-	err = r.handlePollingIfConfigured(resourceLocalData, providerConfig, operation.Responses, res.StatusCode, schema.TimeoutDelete)
+	err = r.handlePollingIfConfigured(nil, resourceLocalData, providerConfig, operation.Responses, res.StatusCode, schema.TimeoutDelete)
 	if err != nil {
 		return fmt.Errorf("polling mechanism failed after DELETE %s call with response status code (%d): %s", resourceIDURL, res.StatusCode, err)
 	}
@@ -203,35 +201,42 @@ func (r resourceFactory) delete(resourceLocalData *schema.ResourceData, i interf
 	return nil
 }
 
-func (r resourceFactory) handlePollingIfConfigured(resourceLocalData *schema.ResourceData, providerConfig providerConfig, responses *spec.Responses, responseStatusCode int, timeoutFor string) error {
-	if pollingEnabled, response := r.resourceInfo.isResourcePollingEnabled(responses, responseStatusCode); pollingEnabled {
-		targetStatuses, err := r.resourceInfo.getResourcePollTargetStatuses(*response)
-		if err != nil {
-			return err
-		}
-		pendingStatuses, err := r.resourceInfo.getResourcePollPendingStatuses(*response)
-		if err != nil {
-			return err
-		}
+func (r resourceFactory) handlePollingIfConfigured(responsePayload *map[string]interface{}, resourceLocalData *schema.ResourceData, providerConfig providerConfig, responses *spec.Responses, responseStatusCode int, timeoutFor string) error {
+	pollingEnabled, response := r.resourceInfo.isResourcePollingEnabled(responses, responseStatusCode)
 
-		log.Printf("[DEBUG] target statuses (%s); pending statuses (%s)", targetStatuses, pendingStatuses)
-		log.Printf("[INFO] Waiting for resource '%s' to reach a completion status (%s)", r.resourceInfo.name, targetStatuses)
+	if !pollingEnabled {
+		return nil
+	}
 
-		stateConf := &resource.StateChangeConf{
-			Pending:      pendingStatuses,
-			Target:       targetStatuses,
-			Refresh:      r.resourceStateRefreshFunc(resourceLocalData, providerConfig),
-			Timeout:      resourceLocalData.Timeout(timeoutFor),
-			PollInterval: 5 * time.Second,
-			MinTimeout:   10 * time.Second,
-			Delay:        1 * time.Second,
-		}
+	targetStatuses, err := r.resourceInfo.getResourcePollTargetStatuses(*response)
+	if err != nil {
+		return err
+	}
+	pendingStatuses, err := r.resourceInfo.getResourcePollPendingStatuses(*response)
+	if err != nil {
+		return err
+	}
 
-		// Wait, catching any errors
-		_, err = stateConf.WaitForState()
-		if err != nil {
-			return fmt.Errorf("error waiting for resource to reach a completion status (%s) [valid pending statuses (%s)]: %s", targetStatuses, pendingStatuses, err)
-		}
+	log.Printf("[DEBUG] target statuses (%s); pending statuses (%s)", targetStatuses, pendingStatuses)
+	log.Printf("[INFO] Waiting for resource '%s' to reach a completion status (%s)", r.resourceInfo.name, targetStatuses)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      pendingStatuses,
+		Target:       targetStatuses,
+		Refresh:      r.resourceStateRefreshFunc(resourceLocalData, providerConfig),
+		Timeout:      resourceLocalData.Timeout(timeoutFor),
+		PollInterval: 5 * time.Second,
+		MinTimeout:   10 * time.Second,
+		Delay:        1 * time.Second,
+	}
+
+	// Wait, catching any errors
+	remoteData, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for resource to reach a completion status (%s) [valid pending statuses (%s)]: %s", targetStatuses, pendingStatuses, err)
+	}
+	if responsePayload != nil {
+		*responsePayload = remoteData.(map[string]interface{})
 	}
 	return nil
 }
@@ -243,7 +248,7 @@ func (r resourceFactory) resourceStateRefreshFunc(resourceLocalData *schema.Reso
 		if err != nil {
 			if openapiErr, ok := err.(openapierr.Error); ok {
 				if openapierr.NotFound == openapiErr.Code() {
-					return "", "destroyed", nil
+					return remoteData, "destroyed", nil
 				}
 			}
 			return nil, "", fmt.Errorf("error on retrieving resource '%s' (%s) when waiting: %s", r.resourceInfo.name, resourceLocalData.Id(), err)


### PR DESCRIPTION
- this change is needed specially when terraform handles updates/deletions doing a
refresh first (performing a read call) in which case if an error is thrown then updates/deletes will
not work as terraform will stop the execution right away. The reading handler
will wipe out the state of a resource if its not found remotely which is
the expected behaviour

- allow 404 when checking returned status code on deletion. if 404 that means
resource has been deleted already...also even if polling is enabled, the polling
mechanism will also capture that and return successfully

- increased the timeout duration to meet service providers APIs where operations
take more than 1 min. Setting it to 10 tentatively for now.

- save one extra read call by just using the payload received from either the first call response or if enabled the latest payload received from the polling request

## Proposed changes

Please add as many details as possible about the change here. Does this Pull Request resolve any open issue? If so, please 
make sure to link to that issue:
                                                              
Fixes: # 

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [x] Bug-fix (change that fixes current functionality)
- [ ] New feature (change that adds new functionality)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'make test' locally from the terraform_provider_api folder and no errors were found
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)