### PR TITLE
register to the provider schemes security definitions that are not global schemes

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"testing"
 	. "github.com/smartystreets/goconvey/convey"
+	"testing"
 )
 
 func TestGetProviderName(t *testing.T) {

--- a/openapi/provider_factory.go
+++ b/openapi/provider_factory.go
@@ -56,6 +56,20 @@ func (p providerFactory) createProvider() (*schema.Provider, error) {
 // - specific headers used in operations
 func (p providerFactory) createTerraformProviderSchema() (map[string]*schema.Schema, error) {
 	s := map[string]*schema.Schema{}
+
+	// Add all security definitions as optional properties
+	securityDefinitions, err := p.specAnalyser.GetSecurity().GetAPIKeySecurityDefinitions()
+	if err != nil {
+		return nil, err
+	}
+	for _, securityDefinition := range *securityDefinitions {
+		s[securityDefinition.getTerraformConfigurationName()] = &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		}
+	}
+
+	// Override security definitions to required if they are global security schemes
 	globalSecuritySchemes, err := p.specAnalyser.GetSecurity().GetGlobalSecuritySchemes()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This ensures if a security definitions that is not global is used for instance inside an operation the provider can still be configured accordingly

## Proposed changes

Please add as many details as possible about the change here. Does this Pull Request resolve any open issue? 
If so, please make sure to link to that issue:
                                                              
Fixes: #68 

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [x] Bug-fix (change that fixes current functionality)
- [ ] New feature (change that adds new functionality)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'make test' locally from the terraform_provider_api folder and no errors were found
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)