### PR TITLE
Enhance error output when tf config is missing values for headers and security definitions

### DIFF
--- a/openapi/provider_factory.go
+++ b/openapi/provider_factory.go
@@ -67,6 +67,7 @@ func (p providerFactory) createTerraformProviderSchema() (map[string]*schema.Sch
 			Type:     schema.TypeString,
 			Optional: true,
 		}
+		log.Printf("[DEBUG] registered optional security definition '%s' into provider schema", securityDefinition.getTerraformConfigurationName())
 	}
 
 	// Override security definitions to required if they are global security schemes
@@ -79,6 +80,7 @@ func (p providerFactory) createTerraformProviderSchema() (map[string]*schema.Sch
 			Type:     schema.TypeString,
 			Required: true,
 		}
+		log.Printf("[DEBUG] registered required security scheme '%s' into provider schema", securityScheme.getTerraformConfigurationName())
 	}
 	headers, err := p.specAnalyser.GetAllHeaderParameters()
 	if err != nil {
@@ -158,7 +160,10 @@ func (p providerFactory) createProviderConfig(data *schema.ResourceData) (*provi
 	if err != nil {
 		return nil, err
 	}
-	providerConfiguration := newProviderConfiguration(headers, securityDefinitions, data)
+	providerConfiguration, err := newProviderConfiguration(headers, securityDefinitions, data)
+	if err != nil {
+		return nil, err
+	}
 	return providerConfiguration, nil
 }
 


### PR DESCRIPTION
## Proposed changes

Please add as many details as possible about the change here. Does this Pull Request resolve any open issue? 
If so, please make sure to link to that issue:
                                                              
If the security definitions or header values were not provided in the terraform configuration the error displayed was not very user friendly and would lead to confusion. This makes sure that proper error message is displayed in such scenario so the user can fix the issue and provide the corresponding missing values in the terraform configuration.

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [ ] Bug-fix (change that fixes current functionality)
- [ ] New feature (change that adds new functionality)
- [x] Enhancement (improvements to current functionality)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'make test' locally from the terraform_provider_api folder and no errors were found
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)