### PR TITLE
fix map race condition issue

### DIFF
--- a/openapi/openapi_client_test.go
+++ b/openapi/openapi_client_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -453,7 +454,8 @@ func TestGetResourceURL(t *testing.T) {
 		regionProperty := newStringSchemaDefinitionPropertyWithDefaults(providerPropertyRegion, "", true, false, expectedRegion)
 		s := newTestSchema(regionProperty)
 		providerConfiguration := providerConfiguration{
-			data: s.getResourceData(t),
+			data:  s.getResourceData(t),
+			mutex: &sync.Mutex{},
 		}
 		providerClient := &ProviderClient{
 			openAPIBackendConfiguration: &specStubBackendConfiguration{
@@ -495,7 +497,8 @@ func TestGetResourceURL(t *testing.T) {
 		regionProperty := newStringSchemaDefinitionPropertyWithDefaults(providerPropertyRegion, "", true, false, emptyRegionProvidedByUser)
 		s := newTestSchema(regionProperty)
 		providerConfiguration := providerConfiguration{
-			data: s.getResourceData(t),
+			data:  s.getResourceData(t),
+			mutex: &sync.Mutex{},
 		}
 		providerClient := &ProviderClient{
 			openAPIBackendConfiguration: &specStubBackendConfiguration{
@@ -563,7 +566,8 @@ func TestGetResourceURL(t *testing.T) {
 		regionProperty := newStringSchemaDefinitionPropertyWithDefaults(providerPropertyRegion, "", true, false, emptyRegionProvidedByUser)
 		s := newTestSchema(regionProperty)
 		providerConfiguration := providerConfiguration{
-			data: s.getResourceData(t),
+			data:  s.getResourceData(t),
+			mutex: &sync.Mutex{},
 		}
 		providerClient := &ProviderClient{
 			openAPIBackendConfiguration: &specStubBackendConfiguration{
@@ -594,7 +598,8 @@ func TestGetResourceURL(t *testing.T) {
 		regionProperty := newStringSchemaDefinitionPropertyWithDefaults(providerPropertyRegion, "", true, false, "us-east1")
 		s := newTestSchema(regionProperty)
 		providerConfiguration := providerConfiguration{
-			data: s.getResourceData(t),
+			data:  s.getResourceData(t),
+			mutex: &sync.Mutex{},
 		}
 		providerClient := &ProviderClient{
 			openAPIBackendConfiguration: &specStubBackendConfiguration{

--- a/openapi/provider_configuration_test.go
+++ b/openapi/provider_configuration_test.go
@@ -133,6 +133,7 @@ func TestGetRegion(t *testing.T) {
 		s := newTestSchema()
 		providerConfiguration := providerConfiguration{
 			data: s.getResourceData(t),
+			mutex: &sync.Mutex{},
 		}
 		Convey("When getRegion() method is called", func() {
 			value := providerConfiguration.getRegion()

--- a/openapi/provider_configuration_test.go
+++ b/openapi/provider_configuration_test.go
@@ -2,6 +2,7 @@ package openapi
 
 import (
 	. "github.com/smartystreets/goconvey/convey"
+	"sync"
 	"testing"
 )
 
@@ -145,7 +146,8 @@ func TestGetRegion(t *testing.T) {
 		regionProperty := newStringSchemaDefinitionPropertyWithDefaults(providerPropertyRegion, "", true, false, expectedRegion)
 		s := newTestSchema(regionProperty)
 		providerConfiguration := providerConfiguration{
-			data: s.getResourceData(t),
+			data:  s.getResourceData(t),
+			mutex: &sync.Mutex{},
 		}
 		Convey("When getRegion() method is called", func() {
 			value := providerConfiguration.getRegion()


### PR DESCRIPTION
- this was introduced when multiregion support was added on the provider
levelm since getRegion is accessing the dataResource object which can
potentially be accessed in parallel by terraform causing concurrent map
issues

## Proposed changes

Please add as many details as possible about the change here. Does this Pull Request resolve any open issue? 
If so, please make sure to link to that issue:
                                                              
Fixes: #88 

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [ x] Bug-fix (change that fixes current functionality)
- [ ] New feature (change that adds new functionality)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'make test' locally from the terraform_provider_api folder and no errors were found
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)