### PR TITLE
Feature/Support expanding tilde in external file path

### DIFF
--- a/docs/plugin_configuration_schema.md
+++ b/docs/plugin_configuration_schema.md
@@ -91,7 +91,7 @@ Describes the schema configuration for the service provider:
 
 Field Name | Type | Description
 ---|:---:|---
-file | `string` | Defines the location where the swagger document is hosted. The value must be either a valid formatted URL or a path to a swagger file stored in the disk
+file | `string` | Defines the location where the swagger document is hosted. The value must be either a valid formatted URL or a path to a swagger file stored in the disk. Paths starting with `~` will be expanded to user's home directory
 key_name | `string` | Defines the key name of the property to look for in the `file`. The file must be JSON formatted if this property is populated. The value must be formatted using the [JsonPath syntax](https://github.com/oliveagle/jsonpath)
 content_type | `string` | Defines the type of content in the ```file```. Supported values are: raw, json
 

--- a/openapi/test_utils.go
+++ b/openapi/test_utils.go
@@ -2,7 +2,9 @@ package openapi
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
+	"io/ioutil"
 	"log"
+	"os"
 	"testing"
 )
 
@@ -137,4 +139,10 @@ func (s *testSchemaDefinition) getResourceData(t *testing.T) *schema.ResourceDat
 	}
 	resourceLocalData := schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
 	return resourceLocalData
+}
+
+func createTmpFile(data string) (*os.File, error) {
+	f, err := ioutil.TempFile("", "")
+	f.Write([]byte(data))
+	return f, err
 }

--- a/openapi/utils.go
+++ b/openapi/utils.go
@@ -21,8 +21,16 @@ func sPrettyPrint(v interface{}) string {
 	return string(b)
 }
 
-func getFileContent(filePath string) (string, error) {
+func expandPath(filePath string) (string, error) {
 	fullPath, err := homedir.Expand(filePath)
+	if err != nil {
+		return "", err
+	}
+	return fullPath, err
+}
+
+func getFileContent(filePath string) (string, error) {
+	fullPath, err := expandPath(filePath)
 	if err != nil {
 		return "", err
 	}

--- a/openapi/utils.go
+++ b/openapi/utils.go
@@ -2,6 +2,7 @@ package openapi
 
 import (
 	"encoding/json"
+	"github.com/mitchellh/go-homedir"
 	"io/ioutil"
 	"log"
 )
@@ -21,7 +22,11 @@ func sPrettyPrint(v interface{}) string {
 }
 
 func getFileContent(filePath string) (string, error) {
-	data, err := ioutil.ReadFile(filePath)
+	fullPath, err := homedir.Expand(filePath)
+	if err != nil {
+		return "", err
+	}
+	data, err := ioutil.ReadFile(fullPath)
 	if err != nil {
 		return "", err
 	}

--- a/openapi/utils_test.go
+++ b/openapi/utils_test.go
@@ -1,0 +1,56 @@
+package openapi
+
+import (
+	"fmt"
+	"github.com/mitchellh/go-homedir"
+	. "github.com/smartystreets/goconvey/convey"
+	"os"
+	"testing"
+)
+
+func TestExpandPath(t *testing.T) {
+	Convey("Given a file with absolute path", t, func() {
+		expectedPath := "/Users/username/.terraform/plugins"
+		Convey("When expandPath is called", func() {
+			path, err := expandPath(expectedPath)
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the path should be the same as the input", func() {
+				So(path, ShouldEqual, path)
+			})
+		})
+	})
+	Convey("Given a file starting with ~", t, func() {
+		homePath := "~/some_folder"
+		Convey("When expandPath is called", func() {
+			path, err := expandPath(homePath)
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the path returned should be expanded with the home dir", func() {
+				// Getting home dir to make the test OS-agnostic
+				homeDir, _ := homedir.Dir()
+				So(path, ShouldEqual, fmt.Sprintf("%s/%s", homeDir, "some_folder"))
+			})
+		})
+	})
+}
+
+func TestGetFileContent(t *testing.T) {
+	Convey("Given a file", t, func() {
+		expectedContent := "some content"
+		f, err := createTmpFile(expectedContent)
+		defer os.Remove(f.Name())
+		So(err, ShouldBeNil)
+		Convey("When getFileContent is called", func() {
+			content, err := getFileContent(f.Name())
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the content should be the expected one", func() {
+				So(content, ShouldEqual, expectedContent)
+			})
+		})
+	})
+}


### PR DESCRIPTION
## Proposed changes

I would like to provide a configuration yaml file for my terraform provider that is static and does not require the user to edit. Because I am using a static API token for auth, I want to support a path to a file in the user's home directory.  For example, I would like to hardcode the path to: `~/.service.json`. Unfortunately, the current code requires specifying the full path.

This change adds support for expanding the tilde `~` to the executing user's home path, if it is the first character of the path.

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [ ] Bug-fix (change that fixes current functionality)
- [x] New feature (change that adds new functionality)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'make test' locally from the terraform_provider_api folder and no errors were found
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)