### PR TITLE
add user agent support 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ RELEASE_TAG?="$(GITHUB_VERSION)"
 RELEASE_MESSAGE?="$(GITHUB_VERSION)"
 COMMIT :=$(shell git rev-parse --verify --short HEAD)
 DATE :=$(shell date +'%FT%TZ%z')
-LDFLAGS = '-s -w -extldflags "-static" -X "github.com/dikhan/terraform-provider-openapi/openapi/version.Version=$(VERSION)" -X "github.com/dikhan/terraform-provider-openapi/openapi/version.Commit=$(COMMIT)" -X "github.com/dikhan/terraform-provider-openapi/openapi/version.Date=$(DATE)"'
+REPO=github.com/dikhan/terraform-provider-openapi
+LDFLAGS = '-s -w -extldflags "-static" -X "$(REPO)/version.Version=$(VERSION)" -X "$(REPO)/openapi/version.Commit=$(COMMIT)" -X "$(REPO)/openapi/version.Date=$(DATE)"'
 
 PROVIDER_NAME?=""
 TF_CMD?="plan"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ RELEASE_TAG?="$(GITHUB_VERSION)"
 RELEASE_MESSAGE?="$(GITHUB_VERSION)"
 COMMIT :=$(shell git rev-parse --verify --short HEAD)
 DATE :=$(shell date +'%FT%TZ%z')
-LDFLAGS = '-s -w -extldflags "-static" -X "main.version=$(VERSION)" -X "main.commit=$(COMMIT)" -X "main.date=$(DATE)"'
+LDFLAGS = '-s -w -extldflags "-static" -X "github.com/dikhan/terraform-provider-openapi/openapi/version.Version=$(VERSION)" -X "github.com/dikhan/terraform-provider-openapi/openapi/version.Commit=$(COMMIT)" -X "github.com/dikhan/terraform-provider-openapi/openapi/version.Date=$(DATE)"'
 
 PROVIDER_NAME?=""
 TF_CMD?="plan"

--- a/main.go
+++ b/main.go
@@ -5,21 +5,16 @@ import (
 
 	"fmt"
 	"github.com/dikhan/terraform-provider-openapi/openapi"
+	"github.com/dikhan/terraform-provider-openapi/openapi/version"
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
 	"os"
 	"regexp"
 )
 
-var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
-)
-
 func main() {
 
-	log.Printf("Running OpenAPI Terraform Provider v%s-%s; Released on: %s", version, commit, date)
+	log.Printf("Running OpenAPI Terraform Provider v%s-%s; Released on: %s", version.Version, version.Commit, version.Date)
 
 	ex, err := os.Executable()
 	if err != nil {

--- a/openapi/headers.go
+++ b/openapi/headers.go
@@ -1,0 +1,7 @@
+package openapi
+
+// HTTP headers
+const (
+	authorization                 = "Authorization"
+	userAgent                     = "User-Agent"
+)

--- a/openapi/headers.go
+++ b/openapi/headers.go
@@ -2,6 +2,6 @@ package openapi
 
 // HTTP headers
 const (
-	authorization                 = "Authorization"
-	userAgent                     = "User-Agent"
+	authorization = "Authorization"
+	userAgent     = "User-Agent"
 )

--- a/openapi/openapi_client.go
+++ b/openapi/openapi_client.go
@@ -106,7 +106,7 @@ func (o *ProviderClient) performRequest(method httpMethodSupported, resourceURL 
 }
 
 func (o *ProviderClient) appendUserAgentHeader(headers map[string]string, value string) {
-	headers["User-Agent"] = value
+	headers[userAgent] = value
 }
 
 // logHeadersSafely logs the header names sent to the APIs but the values are redacted for security reasons in case

--- a/openapi/openapi_client.go
+++ b/openapi/openapi_client.go
@@ -2,11 +2,11 @@ package openapi
 
 import (
 	"fmt"
+	"github.com/dikhan/terraform-provider-openapi/openapi/version"
 	"log"
 	"net/http"
 	"runtime"
 	"strings"
-	"terraform-provider-openapi/openapi/version"
 
 	"github.com/dikhan/http_goclient"
 )

--- a/openapi/openapi_client.go
+++ b/openapi/openapi_client.go
@@ -2,11 +2,11 @@ package openapi
 
 import (
 	"fmt"
-	"github.com/dikhan/terraform-provider-openapi/openapi/version"
 	"log"
 	"net/http"
 	"runtime"
 	"strings"
+	"terraform-provider-openapi/openapi/version"
 
 	"github.com/dikhan/http_goclient"
 )

--- a/openapi/openapi_client.go
+++ b/openapi/openapi_client.go
@@ -6,7 +6,8 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
-	"terraform-provider-openapi/openapi/version"
+
+	"github.com/dikhan/terraform-provider-openapi/openapi/version"
 
 	"github.com/dikhan/http_goclient"
 )

--- a/openapi/openapi_client_test.go
+++ b/openapi/openapi_client_test.go
@@ -91,6 +91,7 @@ func TestAppendUserAgentHeader(t *testing.T) {
 				value, exists := headers["User-Agent"]
 				So(exists, ShouldBeTrue)
 				So(value, ShouldEqual, expectedHeaderValue)
+				So(headers["Some-Header"], ShouldEqual, "some header value")
 			})
 		})
 		Convey("When appendUserAgentHeader with header map containing User-Agent and new header value", func() {
@@ -103,22 +104,6 @@ func TestAppendUserAgentHeader(t *testing.T) {
 			})
 		})
 	})
-	//Convey("Given a providerClient", t, func() {
-	//	providerClient := &ProviderClient{}
-	//	Convey("When appendUserAgentHeader with empty header map and some header value", t, func() {
-	//		headers := map[string]string{}
-	//		expectedHeaderValue := "some user agent header value"
-	//		providerClient.appendUserAgentHeader(headers, expectedHeaderValue)
-	//		Convey("Then the header value should exist in the header map with correct value", func() {
-	//			//value, exists := headers["User-Agent"]
-	//			//So(exists, ShouldBeTrue)
-	//			//So(value, ShouldEqual, expectedHeaderValue)
-	//		})
-	//	})
-	//	//Convey("When appendUserAgentHeader with non-empty header map and some header value", t, func() {
-	//	//
-	//	//})
-	//})
 }
 
 func TestGetResourceIDURL(t *testing.T) {
@@ -737,6 +722,7 @@ func TestPerformRequest(t *testing.T) {
 			Convey("And then client should have received the right Headers with the right values", func() {
 				So(httpClient.Headers, ShouldContainKey, expectedHeader)
 				So(httpClient.Headers[expectedHeader], ShouldEqual, expectedHeaderValue)
+				So(httpClient.Headers, ShouldContainKey, "User-Agent")
 			})
 			Convey("And then client should have received the right request payload", func() {
 				So(httpClient.In.(map[string]interface{}), ShouldContainKey, expectedReqPayloadProperty1)

--- a/openapi/openapi_client_test.go
+++ b/openapi/openapi_client_test.go
@@ -79,7 +79,7 @@ func TestAppendUserAgentHeader(t *testing.T) {
 			headers := map[string]string{}
 			providerClient.appendUserAgentHeader(headers, expectedHeaderValue)
 			Convey("Then the user agent header value should exist in the header map with correct value", func() {
-				value, exists := headers["User-Agent"]
+				value, exists := headers[userAgent]
 				So(exists, ShouldBeTrue)
 				So(value, ShouldEqual, expectedHeaderValue)
 			})
@@ -88,17 +88,17 @@ func TestAppendUserAgentHeader(t *testing.T) {
 			headers := map[string]string{"Some-Header": "some header value"}
 			providerClient.appendUserAgentHeader(headers, expectedHeaderValue)
 			Convey("Then the user agent header should exist in the header map with correct value", func() {
-				value, exists := headers["User-Agent"]
+				value, exists := headers[userAgent]
 				So(exists, ShouldBeTrue)
 				So(value, ShouldEqual, expectedHeaderValue)
 				So(headers["Some-Header"], ShouldEqual, "some header value")
 			})
 		})
 		Convey("When appendUserAgentHeader with header map containing User-Agent and new header value", func() {
-			headers := map[string]string{"User-Agent": "some existing user agent header value"}
+			headers := map[string]string{userAgent: "some existing user agent header value"}
 			providerClient.appendUserAgentHeader(headers, expectedHeaderValue)
 			Convey("Then the user agent header should exist in the header map with correct value", func() {
-				value, exists := headers["User-Agent"]
+				value, exists := headers[userAgent]
 				So(exists, ShouldBeTrue)
 				So(value, ShouldEqual, expectedHeaderValue)
 			})
@@ -727,7 +727,7 @@ func TestPerformRequest(t *testing.T) {
 				So(httpClient.Headers[expectedHeader], ShouldEqual, expectedHeaderValue)
 				So(httpClient.Headers, ShouldContainKey, headerParameter.Name)
 				So(httpClient.Headers[headerParameter.Name], ShouldEqual, providerConfiguration.Headers[headerParameter.TerraformName])
-				So(httpClient.Headers, ShouldContainKey, "User-Agent")
+				So(httpClient.Headers, ShouldContainKey, userAgent)
 			})
 			Convey("And then client should have received the right request payload", func() {
 				So(httpClient.In.(map[string]interface{}), ShouldContainKey, expectedReqPayloadProperty1)
@@ -833,8 +833,8 @@ func TestProviderClientPost(t *testing.T) {
 				So(httpClient.Headers[headerParameter.Name], ShouldEqual, providerConfiguration.Headers[headerParameter.TerraformName])
 			})
 			Convey("And then client should have received the right User-Agent header and the expected value", func() {
-				So(httpClient.Headers, ShouldContainKey, "User-Agent")
-				So(httpClient.Headers["User-Agent"], ShouldContainSubstring, "OpenAPI Terraform Provider")
+				So(httpClient.Headers, ShouldContainKey, userAgent)
+				So(httpClient.Headers[userAgent], ShouldContainSubstring, "OpenAPI Terraform Provider")
 			})
 			Convey("And then client should have received the right request payload", func() {
 				So(httpClient.In.(map[string]interface{}), ShouldContainKey, expectedReqPayloadProperty1)

--- a/openapi/openapi_client_test.go
+++ b/openapi/openapi_client_test.go
@@ -770,7 +770,10 @@ func TestPerformRequest(t *testing.T) {
 func TestProviderClientPost(t *testing.T) {
 	Convey("Given a providerClient set up with stub auth that injects some headers to the request", t, func() {
 		httpClient := &http_goclient.HttpClientStub{}
-		providerConfiguration := providerConfiguration{}
+		headerParameter := SpecHeaderParam{"Operation-Specific-Header", "operation_specific_header"}
+		providerConfiguration := providerConfiguration{
+			Headers: map[string]string{headerParameter.TerraformName: "some-value"},
+		}
 		expectedHeader := "Authentication"
 		expectedHeaderValue := "Bearer secret!"
 		apiAuthenticator := &specStubAuthenticator{
@@ -795,7 +798,7 @@ func TestProviderClientPost(t *testing.T) {
 			specStubResource := &specStubResource{
 				path: "/v1/resource",
 				resourcePostOperation: &specResourceOperation{
-					HeaderParameters: SpecHeaderParameters{},
+					HeaderParameters: SpecHeaderParameters{headerParameter},
 					responses:        specResponses{},
 					SecuritySchemes:  SpecSecuritySchemes{},
 				},
@@ -821,9 +824,17 @@ func TestProviderClientPost(t *testing.T) {
 				expectedPath := specStubResource.path
 				So(httpClient.URL, ShouldEqual, fmt.Sprintf("%s://%s%s%s", expectedProtocol, expectedHost, expectedBasePath, expectedPath))
 			})
-			Convey("And then client should have received the right Headers with the right values", func() {
+			Convey("And then client should have received the right Authentication header and expected value", func() {
 				So(httpClient.Headers, ShouldContainKey, expectedHeader)
 				So(httpClient.Headers[expectedHeader], ShouldEqual, expectedHeaderValue)
+			})
+			Convey("And then client should have received the right operation header and the expected value", func() {
+				So(httpClient.Headers, ShouldContainKey, headerParameter.Name)
+				So(httpClient.Headers[headerParameter.Name], ShouldEqual, providerConfiguration.Headers[headerParameter.TerraformName])
+			})
+			Convey("And then client should have received the right User-Agent header and the expected value", func() {
+				So(httpClient.Headers, ShouldContainKey, "User-Agent")
+				So(httpClient.Headers["User-Agent"], ShouldContainSubstring, "OpenAPI Terraform Provider")
 			})
 			Convey("And then client should have received the right request payload", func() {
 				So(httpClient.In.(map[string]interface{}), ShouldContainKey, expectedReqPayloadProperty1)

--- a/openapi/openapi_client_test.go
+++ b/openapi/openapi_client_test.go
@@ -672,7 +672,10 @@ func TestGetResourceURL(t *testing.T) {
 func TestPerformRequest(t *testing.T) {
 	Convey("Given a providerClient set up with stub auth that injects some headers to the request", t, func() {
 		httpClient := &http_goclient.HttpClientStub{}
-		providerConfiguration := providerConfiguration{}
+		headerParameter := SpecHeaderParam{"Operation-Specific-Header", "operation_specific_header"}
+		providerConfiguration := providerConfiguration{
+			Headers: map[string]string{headerParameter.TerraformName: "some-value"},
+		}
 		expectedHeader := "Authentication"
 		expectedHeaderValue := "Bearer secret!"
 		apiAuthenticator := &specStubAuthenticator{
@@ -693,9 +696,9 @@ func TestPerformRequest(t *testing.T) {
 			providerConfiguration: providerConfiguration,
 			apiAuthenticator:      apiAuthenticator,
 		}
-		Convey("When performRequest POST method is called with a resourceURL, a requestPayload and an empty responsePayload", func() {
+		Convey("When performRequest POST method is called with a resourceURL, a requestPayload, an empty responsePayload, and header parameters", func() {
 			resourcePostOperation := &specResourceOperation{
-				HeaderParameters: SpecHeaderParameters{},
+				HeaderParameters: SpecHeaderParameters{headerParameter},
 				responses:        specResponses{},
 				SecuritySchemes:  SpecSecuritySchemes{},
 			}
@@ -722,6 +725,8 @@ func TestPerformRequest(t *testing.T) {
 			Convey("And then client should have received the right Headers with the right values", func() {
 				So(httpClient.Headers, ShouldContainKey, expectedHeader)
 				So(httpClient.Headers[expectedHeader], ShouldEqual, expectedHeaderValue)
+				So(httpClient.Headers, ShouldContainKey, headerParameter.Name)
+				So(httpClient.Headers[headerParameter.Name], ShouldEqual, providerConfiguration.Headers[headerParameter.TerraformName])
 				So(httpClient.Headers, ShouldContainKey, "User-Agent")
 			})
 			Convey("And then client should have received the right request payload", func() {

--- a/openapi/openapi_spec_authenticator_api_test.go
+++ b/openapi/openapi_spec_authenticator_api_test.go
@@ -63,7 +63,7 @@ func TestFetchRequiredAuthenticators(t *testing.T) {
 	Convey("Given a provider configuration containing an 'apiKey' type security definition with name 'apikey_auth' and an operation that requires api key header authentication", t, func() {
 		securityPolicyName := "apikey_auth"
 		expectedAPIKey := apiKey{
-			name:  "Authorization",
+			name:  authorization,
 			value: "superSecretKey",
 		}
 		providerConfig := providerConfiguration{
@@ -95,7 +95,7 @@ func TestFetchRequiredAuthenticators(t *testing.T) {
 			SecuritySchemaDefinitions: map[string]specAPIKeyAuthenticator{
 				securityPolicyName: apiKeyHeaderAuthenticator{
 					apiKey{
-						name:  "Authorization",
+						name:  authorization,
 						value: "superSecretKey",
 					},
 				},
@@ -122,7 +122,7 @@ func TestPrepareAuth(t *testing.T) {
 			SecuritySchemaDefinitions: map[string]specAPIKeyAuthenticator{
 				securityPolicyName: apiKeyHeaderAuthenticator{
 					apiKey{
-						name:  "Authorization",
+						name:  authorization,
 						value: "superSecretKey",
 					},
 				},
@@ -137,10 +137,10 @@ func TestPrepareAuth(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 			Convey("Then the map returned should contain a key 'Authorization'", func() {
-				So(authContext.headers, ShouldContainKey, "Authorization")
+				So(authContext.headers, ShouldContainKey, authorization)
 			})
 			Convey("And the value of the 'Authorization' entry should be superSecretKey", func() {
-				So(authContext.headers["Authorization"], ShouldEqual, "superSecretKey")
+				So(authContext.headers[authorization], ShouldEqual, "superSecretKey")
 			})
 			Convey("And the url returned should be the same as the input parameter ", func() {
 				So(authContext.url, ShouldEqual, url)
@@ -154,7 +154,7 @@ func TestPrepareAuth(t *testing.T) {
 			SecuritySchemaDefinitions: map[string]specAPIKeyAuthenticator{
 				securityPolicyName: apiKeyQueryAuthenticator{
 					apiKey{
-						name:  "Authorization",
+						name:  authorization,
 						value: "superSecretKey",
 					},
 				},
@@ -172,7 +172,7 @@ func TestPrepareAuth(t *testing.T) {
 				So(authContext.headers, ShouldBeEmpty)
 			})
 			Convey("And the url returned should be the same as the input parameter ", func() {
-				So(authContext.url, ShouldEqual, fmt.Sprintf("%s?%s=%s", url, "Authorization", "superSecretKey"))
+				So(authContext.url, ShouldEqual, fmt.Sprintf("%s?%s=%s", url, authorization, "superSecretKey"))
 			})
 		})
 	})
@@ -184,7 +184,7 @@ func TestPrepareAuth(t *testing.T) {
 			SecuritySchemaDefinitions: map[string]specAPIKeyAuthenticator{
 				apiKeyHeaderSecurityPolicyName: apiKeyHeaderAuthenticator{
 					apiKey{
-						name:  "Authorization",
+						name:  authorization,
 						value: "superSecretKeyInHeader",
 					},
 				},
@@ -207,8 +207,8 @@ func TestPrepareAuth(t *testing.T) {
 			Convey("Then both security policies (apikey_header_auth) and (apikey_query_auth), should be the used for auth", func() {
 				// Checking whether the apiKey query mechanism has been picked; otherwise apiKey header must be present - either or
 				So(authContext.url, ShouldEqual, fmt.Sprintf("%s?someQueryParam=superSecretKeyInQuery", url))
-				So(authContext.headers, ShouldContainKey, "Authorization")
-				So(authContext.headers["Authorization"], ShouldEqual, "superSecretKeyInHeader")
+				So(authContext.headers, ShouldContainKey, authorization)
+				So(authContext.headers[authorization], ShouldEqual, "superSecretKeyInHeader")
 			})
 		})
 	})

--- a/openapi/openapi_spec_authenticator_apikey_test.go
+++ b/openapi/openapi_spec_authenticator_apikey_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCreateAPIKeyAuthenticator(t *testing.T) {
 	Convey("Given a secDef of header type and a auth value ", t, func() {
-		secDef := newAPIKeyHeaderSecurityDefinition("header_auth", "Authorization")
+		secDef := newAPIKeyHeaderSecurityDefinition("header_auth", authorization)
 		value := "value"
 		Convey("When createAPIKeyAuthenticator method is constructed", func() {
 			apiKeyAuthenticator := createAPIKeyAuthenticator(secDef, value)
@@ -21,7 +21,7 @@ func TestCreateAPIKeyAuthenticator(t *testing.T) {
 	})
 
 	Convey("Given a secDef of query type and a auth value ", t, func() {
-		secDef := newAPIKeyQuerySecurityDefinition("query_auth", "Authorization")
+		secDef := newAPIKeyQuerySecurityDefinition("query_auth", authorization)
 		value := "value"
 		Convey("When createAPIKeyAuthenticator method is constructed", func() {
 			apiKeyAuthenticator := createAPIKeyAuthenticator(secDef, value)

--- a/openapi/openapi_spec_security_definition_apikey_header_bearer.go
+++ b/openapi/openapi_spec_security_definition_apikey_header_bearer.go
@@ -31,7 +31,7 @@ func (s specAPIKeyHeaderBearerSecurityDefinition) getTerraformConfigurationName(
 }
 
 func (s specAPIKeyHeaderBearerSecurityDefinition) getAPIKey() specAPIKey {
-	return newAPIKeyHeader("Authorization")
+	return newAPIKeyHeader(authorization)
 }
 
 func (s specAPIKeyHeaderBearerSecurityDefinition) buildValue(value string) string {

--- a/openapi/openapi_spec_security_definition_apikey_header_bearer_test.go
+++ b/openapi/openapi_spec_security_definition_apikey_header_bearer_test.go
@@ -72,7 +72,7 @@ func TestAPIKeyHeaderBearerSecurityDefinitionGetAPIKey(t *testing.T) {
 		Convey("When getTerraformConfigurationName method is called", func() {
 			apiKey := specAPIKeyHeaderBearerSecurityDefinition.getAPIKey()
 			Convey("Then the result should contain the right apikey name and location", func() {
-				So(apiKey.Name, ShouldEqual, "Authorization")
+				So(apiKey.Name, ShouldEqual, authorization)
 				So(apiKey.In, ShouldEqual, inHeader)
 			})
 		})

--- a/openapi/openapi_spec_security_definition_apikey_header_test.go
+++ b/openapi/openapi_spec_security_definition_apikey_header_test.go
@@ -22,7 +22,7 @@ func TestNewAPIKeyHeaderSecurityDefinition(t *testing.T) {
 func TestAPIKeyHeaderSecurityDefinitionGetName(t *testing.T) {
 	Convey("Given an APIKeyHeaderSecurityDefinition", t, func() {
 		expectedName := "apikey_name"
-		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition(expectedName, "Authorization")
+		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition(expectedName, authorization)
 		Convey("When getTerraformConfigurationName method is called", func() {
 			name := apiKeyHeaderSecurityDefinition.getName()
 			Convey("Then the result should match the original name", func() {
@@ -34,7 +34,7 @@ func TestAPIKeyHeaderSecurityDefinitionGetName(t *testing.T) {
 
 func TestAPIKeyHeaderSecurityDefinitionGetType(t *testing.T) {
 	Convey("Given an APIKeyHeaderSecurityDefinition", t, func() {
-		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition("apikey_name", "Authorization")
+		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition("apikey_name", authorization)
 		Convey("When getType method is called", func() {
 			secDefType := apiKeyHeaderSecurityDefinition.getType()
 			Convey("Then the result should be securityDefinitionAPIKey", func() {
@@ -46,7 +46,7 @@ func TestAPIKeyHeaderSecurityDefinitionGetType(t *testing.T) {
 
 func TestAPIKeyHeaderSecurityDefinitionGetTerraformConfigurationName(t *testing.T) {
 	Convey("Given an APIKeyHeaderSecurityDefinition with a compliant name", t, func() {
-		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition("apikey_name", "Authorization")
+		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition("apikey_name", authorization)
 		Convey("When getTerraformConfigurationName method is called", func() {
 			secDefTfName := apiKeyHeaderSecurityDefinition.getTerraformConfigurationName()
 			Convey("Then the result should be securityDefinitionAPIKey", func() {
@@ -56,7 +56,7 @@ func TestAPIKeyHeaderSecurityDefinitionGetTerraformConfigurationName(t *testing.
 	})
 
 	Convey("Given an APIKeyHeaderSecurityDefinition with a NON compliant name", t, func() {
-		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition("nonCompliantName", "Authorization")
+		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition("nonCompliantName", authorization)
 		Convey("When getTerraformConfigurationName method is called", func() {
 			secDefTfName := apiKeyHeaderSecurityDefinition.getTerraformConfigurationName()
 			Convey("Then the result should be securityDefinitionAPIKey", func() {
@@ -68,7 +68,7 @@ func TestAPIKeyHeaderSecurityDefinitionGetTerraformConfigurationName(t *testing.
 
 func TestAPIKeyHeaderSecurityDefinitionGetAPIKey(t *testing.T) {
 	Convey("Given an APIKeyHeaderSecurityDefinition", t, func() {
-		expectedAPIKey := "Authorization"
+		expectedAPIKey := authorization
 		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition("apiKeyName", expectedAPIKey)
 		Convey("When getTerraformConfigurationName method is called", func() {
 			apiKey := apiKeyHeaderSecurityDefinition.getAPIKey()
@@ -82,7 +82,7 @@ func TestAPIKeyHeaderSecurityDefinitionGetAPIKey(t *testing.T) {
 
 func TestAPIKeyHeaderSecurityDefinitionBuildValue(t *testing.T) {
 	Convey("Given an APIKeyHeaderSecurityDefinition", t, func() {
-		expectedAPIKey := "Authorization"
+		expectedAPIKey := authorization
 		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition("apiKeyName", expectedAPIKey)
 		Convey("When getTerraformConfigurationName method is called", func() {
 			expectedValue := "someValue"
@@ -96,7 +96,7 @@ func TestAPIKeyHeaderSecurityDefinitionBuildValue(t *testing.T) {
 
 func TestAPIKeyHeaderSecurityDefinitionValidate(t *testing.T) {
 	Convey("Given an APIKeyHeaderSecurityDefinition with a security definition name and an apiKeyName", t, func() {
-		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition("apiKeyName", "Authorization")
+		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition("apiKeyName", authorization)
 		Convey("When validate method is called", func() {
 			err := apiKeyHeaderSecurityDefinition.validate()
 			Convey("Then the error returned should be nil", func() {
@@ -105,7 +105,7 @@ func TestAPIKeyHeaderSecurityDefinitionValidate(t *testing.T) {
 		})
 	})
 	Convey("Given an APIKeyHeaderSecurityDefinition with an empty security definition name and an apiKeyName", t, func() {
-		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition("", "Authorization")
+		apiKeyHeaderSecurityDefinition := newAPIKeyHeaderSecurityDefinition("", authorization)
 		Convey("When validate method is called", func() {
 			err := apiKeyHeaderSecurityDefinition.validate()
 			Convey("Then the error returned should NOT be nil", func() {

--- a/openapi/openapi_spec_security_definition_apikey_query_test.go
+++ b/openapi/openapi_spec_security_definition_apikey_query_test.go
@@ -22,7 +22,7 @@ func TestNewAPIKeyQuerySecurityDefinition(t *testing.T) {
 func TestAPIKeyQuerySecurityDefinitionGetName(t *testing.T) {
 	Convey("Given an APIKeyQuerySecurityDefinition", t, func() {
 		expectedName := "apikey_name"
-		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition(expectedName, "Authorization")
+		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition(expectedName, authorization)
 		Convey("When getTerraformConfigurationName method is called", func() {
 			name := apiKeyQuerySecurityDefinition.getName()
 			Convey("Then the result should match the original name", func() {
@@ -34,7 +34,7 @@ func TestAPIKeyQuerySecurityDefinitionGetName(t *testing.T) {
 
 func TestAPIKeyQuerySecurityDefinitionGetType(t *testing.T) {
 	Convey("Given an APIKeyQuerySecurityDefinition", t, func() {
-		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition("apikey_name", "Authorization")
+		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition("apikey_name", authorization)
 		Convey("When getType method is called", func() {
 			secDefType := apiKeyQuerySecurityDefinition.getType()
 			Convey("Then the result should be securityDefinitionAPIKey", func() {
@@ -46,7 +46,7 @@ func TestAPIKeyQuerySecurityDefinitionGetType(t *testing.T) {
 
 func TestAPIKeyQuerySecurityDefinitionGetTerraformConfigurationName(t *testing.T) {
 	Convey("Given an APIKeyQuerySecurityDefinition with a compliant name", t, func() {
-		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition("apikey_name", "Authorization")
+		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition("apikey_name", authorization)
 		Convey("When getTerraformConfigurationName method is called", func() {
 			secDefTfName := apiKeyQuerySecurityDefinition.getTerraformConfigurationName()
 			Convey("Then the result should be securityDefinitionAPIKey", func() {
@@ -56,7 +56,7 @@ func TestAPIKeyQuerySecurityDefinitionGetTerraformConfigurationName(t *testing.T
 	})
 
 	Convey("Given an APIKeyQuerySecurityDefinition with a NON compliant name", t, func() {
-		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition("nonCompliantName", "Authorization")
+		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition("nonCompliantName", authorization)
 		Convey("When getTerraformConfigurationName method is called", func() {
 			secDefTfName := apiKeyQuerySecurityDefinition.getTerraformConfigurationName()
 			Convey("Then the result should be securityDefinitionAPIKey", func() {
@@ -68,7 +68,7 @@ func TestAPIKeyQuerySecurityDefinitionGetTerraformConfigurationName(t *testing.T
 
 func TestAPIKeyQuerySecurityDefinitionGetAPIKey(t *testing.T) {
 	Convey("Given an APIKeyQuerySecurityDefinition", t, func() {
-		expectedAPIKey := "Authorization"
+		expectedAPIKey := authorization
 		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition("apiKeyName", expectedAPIKey)
 		Convey("When getTerraformConfigurationName method is called", func() {
 			apiKey := apiKeyQuerySecurityDefinition.getAPIKey()
@@ -82,7 +82,7 @@ func TestAPIKeyQuerySecurityDefinitionGetAPIKey(t *testing.T) {
 
 func TestAPIKeyQuerySecurityDefinitionBuildValue(t *testing.T) {
 	Convey("Given an APIKeyQuerySecurityDefinition", t, func() {
-		expectedAPIKey := "Authorization"
+		expectedAPIKey := authorization
 		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition("apiKeyName", expectedAPIKey)
 		Convey("When getTerraformConfigurationName method is called", func() {
 			expectedValue := "someValue"
@@ -96,7 +96,7 @@ func TestAPIKeyQuerySecurityDefinitionBuildValue(t *testing.T) {
 
 func TestAPIKeyQuerySecurityDefinitionValidate(t *testing.T) {
 	Convey("Given an APIKeyQuerySecurityDefinition with a security definition name and an apiKeyName", t, func() {
-		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition("apiKeyName", "Authorization")
+		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition("apiKeyName", authorization)
 		Convey("When validate method is called", func() {
 			err := apiKeyQuerySecurityDefinition.validate()
 			Convey("Then the error returned should be nil", func() {
@@ -105,7 +105,7 @@ func TestAPIKeyQuerySecurityDefinitionValidate(t *testing.T) {
 		})
 	})
 	Convey("Given an APIKeyQuerySecurityDefinition with an empty security definition name and an apiKeyName", t, func() {
-		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition("", "Authorization")
+		apiKeyQuerySecurityDefinition := newAPIKeyQuerySecurityDefinition("", authorization)
 		Convey("When validate method is called", func() {
 			err := apiKeyQuerySecurityDefinition.validate()
 			Convey("Then the error returned should NOT be nil", func() {

--- a/openapi/openapi_spec_security_definitions_test.go
+++ b/openapi/openapi_spec_security_definitions_test.go
@@ -10,7 +10,7 @@ func TestFindSecurityDefinitionFor(t *testing.T) {
 	Convey("Given a SpecSecurityDefinitions", t, func() {
 		expectedSecDefName := "secDefName"
 		s := SpecSecurityDefinitions{
-			newAPIKeyHeaderSecurityDefinition(expectedSecDefName, "Authorization"),
+			newAPIKeyHeaderSecurityDefinition(expectedSecDefName, authorization),
 		}
 		Convey("When findSecurityDefinitionFor method is called with an existing sec def name", func() {
 			secDef := s.findSecurityDefinitionFor(expectedSecDefName)

--- a/openapi/openapi_v2_security_test.go
+++ b/openapi/openapi_v2_security_test.go
@@ -35,7 +35,7 @@ func TestGetAPIKeySecurityDefinitions(t *testing.T) {
 			})
 			Convey("And the security schemes should be of type header bearer", func() {
 				So(secDefs[0], ShouldHaveSameTypeAs, specAPIKeyHeaderBearerSecurityDefinition{})
-				So(secDefs[0].getAPIKey().Name, ShouldEqual, "Authorization")
+				So(secDefs[0].getAPIKey().Name, ShouldEqual, authorization)
 				So(secDefs[0].buildValue("jwtToken"), ShouldEqual, "Bearer jwtToken")
 			})
 		})
@@ -193,7 +193,7 @@ func TestGetGlobalSecuritySchemes(t *testing.T) {
 					SecuritySchemeProps: spec.SecuritySchemeProps{
 						In:   "header",
 						Type: "apiKey",
-						Name: "Authorization",
+						Name: authorization,
 					},
 				},
 			},
@@ -223,7 +223,7 @@ func TestGetGlobalSecuritySchemes(t *testing.T) {
 					SecuritySchemeProps: spec.SecuritySchemeProps{
 						In:   "header",
 						Type: "apiKey",
-						Name: "Authorization",
+						Name: authorization,
 					},
 				},
 			},

--- a/openapi/provider_factory_test.go
+++ b/openapi/provider_factory_test.go
@@ -105,7 +105,7 @@ func TestCreateProvider(t *testing.T) {
 				},
 				security: &specSecurityStub{
 					securityDefinitions: &SpecSecurityDefinitions{
-						newAPIKeyHeaderSecurityDefinition(apiKeyAuthProperty.Name, "Authorization"),
+						newAPIKeyHeaderSecurityDefinition(apiKeyAuthProperty.Name, authorization),
 					},
 					globalSecuritySchemes: createSecuritySchemes([]map[string][]string{
 						{
@@ -150,7 +150,7 @@ func TestCreateProvider(t *testing.T) {
 				},
 				security: &specSecurityStub{
 					securityDefinitions: &SpecSecurityDefinitions{
-						newAPIKeyHeaderSecurityDefinition(apiKeyAuthProperty.Name, "Authorization"),
+						newAPIKeyHeaderSecurityDefinition(apiKeyAuthProperty.Name, authorization),
 					},
 					globalSecuritySchemes: createSecuritySchemes([]map[string][]string{
 						{
@@ -246,7 +246,7 @@ func TestCreateTerraformProviderSchema(t *testing.T) {
 				},
 				security: &specSecurityStub{
 					securityDefinitions: &SpecSecurityDefinitions{
-						newAPIKeyHeaderSecurityDefinition(apiKeyAuthProperty.Name, "Authorization"),
+						newAPIKeyHeaderSecurityDefinition(apiKeyAuthProperty.Name, authorization),
 					},
 					globalSecuritySchemes: createSecuritySchemes([]map[string][]string{
 						{
@@ -294,7 +294,7 @@ func TestCreateTerraformProviderSchema(t *testing.T) {
 			specAnalyser: &specAnalyserStub{
 				security: &specSecurityStub{
 					securityDefinitions: &SpecSecurityDefinitions{
-						newAPIKeyHeaderSecurityDefinition(apiKeyAuthProperty.Name, "Authorization"),
+						newAPIKeyHeaderSecurityDefinition(apiKeyAuthProperty.Name, authorization),
 					},
 					globalSecuritySchemes: createSecuritySchemes([]map[string][]string{
 						{
@@ -329,7 +329,7 @@ func TestCreateTerraformProviderSchema(t *testing.T) {
 				headers: SpecHeaderParameters{},
 				security: &specSecurityStub{
 					securityDefinitions: &SpecSecurityDefinitions{
-						newAPIKeyHeaderSecurityDefinition(globalSecurityDefinitionName, "Authorization"),
+						newAPIKeyHeaderSecurityDefinition(globalSecurityDefinitionName, authorization),
 						newAPIKeyHeaderSecurityDefinition(otherSecurityDefinitionName, "Authorization2"),
 					},
 					globalSecuritySchemes: createSecuritySchemes([]map[string][]string{
@@ -549,7 +549,7 @@ func TestConfigureProvider(t *testing.T) {
 				},
 				security: &specSecurityStub{
 					securityDefinitions: &SpecSecurityDefinitions{
-						newAPIKeyHeaderSecurityDefinition(apiKeyAuthProperty.Name, "Authorization"),
+						newAPIKeyHeaderSecurityDefinition(apiKeyAuthProperty.Name, authorization),
 					},
 					globalSecuritySchemes: createSecuritySchemes([]map[string][]string{
 						{
@@ -580,7 +580,7 @@ func TestCreateProviderConfig(t *testing.T) {
 		apiKeyAuthProperty := newStringSchemaDefinitionPropertyWithDefaults("apikey_auth", "", true, false, "someAuthValue")
 		headerProperty := newStringSchemaDefinitionPropertyWithDefaults("header_name", "", true, false, "someHeaderValue")
 		expectedSecurityDefinitions := SpecSecurityDefinitions{
-			newAPIKeyHeaderSecurityDefinition(apiKeyAuthProperty.Name, "Authorization"),
+			newAPIKeyHeaderSecurityDefinition(apiKeyAuthProperty.Name, authorization),
 		}
 		p := providerFactory{
 			name: "provider",
@@ -623,7 +623,7 @@ func TestCreateProviderConfig(t *testing.T) {
 		var headerNonCompliantNameProperty = newStringSchemaDefinitionPropertyWithDefaults("headerName", "", true, false, "someHeaderValue")
 
 		expectedSecurityDefinitions := SpecSecurityDefinitions{
-			newAPIKeyHeaderSecurityDefinition(apiKeyAuthPreferredNonCompliantNameProperty.Name, "Authorization"),
+			newAPIKeyHeaderSecurityDefinition(apiKeyAuthPreferredNonCompliantNameProperty.Name, authorization),
 		}
 		p := providerFactory{
 			name: "provider",

--- a/openapi/version/version.go
+++ b/openapi/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var (
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+)

--- a/openapi/version/version.go
+++ b/openapi/version/version.go
@@ -5,11 +5,16 @@ import (
 )
 
 var (
+	// Version specifies the version of the OpenAPI Terraform provider
 	Version = "dev"
+	// Commit specifies the commit hash of the OpenAPI Terraform provider at the time of building the binary
 	Commit  = "none"
+	// Date specifies the data which the binary was build
 	Date    = "unknown"
 )
 
+// BuildUserAgent creates based on the Version, Commit, runtime and arch info the user agent string that will
+// be send along all the API requests
 func BuildUserAgent(runtime, arch string) string {
 	return fmt.Sprintf("OpenAPI Terraform Provider/%s-%s (%s/%s)", Version, Commit, runtime, arch)
 }

--- a/openapi/version/version.go
+++ b/openapi/version/version.go
@@ -8,9 +8,9 @@ var (
 	// Version specifies the version of the OpenAPI Terraform provider
 	Version = "dev"
 	// Commit specifies the commit hash of the OpenAPI Terraform provider at the time of building the binary
-	Commit  = "none"
+	Commit = "none"
 	// Date specifies the data which the binary was build
-	Date    = "unknown"
+	Date = "unknown"
 )
 
 // BuildUserAgent creates based on the Version, Commit, runtime and arch info the user agent string that will

--- a/openapi/version/version.go
+++ b/openapi/version/version.go
@@ -1,7 +1,15 @@
 package version
 
+import (
+	"fmt"
+)
+
 var (
 	Version = "dev"
 	Commit  = "none"
 	Date    = "unknown"
 )
+
+func BuildUserAgent(runtime, arch string) string {
+	return fmt.Sprintf("OpenAPI Terraform Provider/%s-%s (%s/%s)", Version, Commit, runtime, arch)
+}

--- a/openapi/version/version_test.go
+++ b/openapi/version/version_test.go
@@ -1,0 +1,22 @@
+package version
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+
+func TestBuildUserAgent(t *testing.T) {
+	Convey("Given a version and a commit hash", t, func() {
+		Version = "someVersion"
+		Commit = "someCommit"
+		Convey("When BuildUserAgent method is called with some runtime", func() {
+			runtime := "linux"
+			arch := "amd64"
+			value := BuildUserAgent(runtime, arch)
+			Convey("Then the value of the header should be the expected one", func() {
+				So(value, ShouldEqual, "OpenAPI Terraform Provider/someVersion-someCommit (linux/amd64)")
+			})
+		})
+	})
+}

--- a/openapi/version/version_test.go
+++ b/openapi/version/version_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 )
 
-
 func TestBuildUserAgent(t *testing.T) {
 	Convey("Given a version and a commit hash", t, func() {
 		Version = "someVersion"


### PR DESCRIPTION
Response to feature request: https://github.com/dikhan/terraform-provider-openapi/issues/83

User agent information is now appended to request header in ```performRequest``` using the following new functions: 
* ```BuildUserAgent```
* ```appendUserAgentHeader```
