### PR TITLE
fix ldgflags to use the new version package instead to bind the stati…

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
     - -a
     - -tags="netgo"
     ldflags:
-    - -s -w -extldflags "-static" -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}"
+    - -s -w -extldflags "-static" -X "github.com/dikhan/terraform-provider-openapi/version.Version={{.Version}}" -X "github.com/dikhan/terraform-provider-openapi/openapi/version.Commit={{.Commit}}" -X "github.com/dikhan/terraform-provider-openapi/openapi/version.Date={{.Date}}"
 
 release:
   name_template: "v{{.Version}}"


### PR DESCRIPTION
## Proposed changes

Fix release yaml goreleaser to bing statically linked variables to the new package version instead.


## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [x] Bug-fix (change that fixes current functionality)
- [ ] New feature (change that adds new functionality)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'make test' locally from the terraform_provider_api folder and no errors were found
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)