### PR TITLE
Feature/add int test for timeout user override

### DIFF
--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -300,7 +300,8 @@ above example*
 
 ###### <a name="xTerraformResourceTimeout">x-terraform-resource-timeout</a>
 
-This extension allows service providers to override the default timeout value for CRUD operations with a different value.
+This extension allows service providers to override the default timeout value for CRUD operations with a different value
+for just the operations that are [asynchronous](https://github.com/dikhan/terraform-provider-openapi/blob/master/docs/how_to.md#xTerraformResourcePollEnabled).
 
 The value must comply with the duration type format. A duration string is a sequence of decimal positive numbers (negative numbers are not allowed),
 each with optional fraction and a unit suffix, such as "300s", "20.5m", "1.5h" or "2h45m".
@@ -321,6 +322,22 @@ paths:
       x-terraform-resource-timeout: "20m" # this means the max timeout for the delete operation to finish is 20 minutes. This overrides the default timeout per operation which is 10 minutes
       ...
 ````
+
+This extension will also enable users to specify a different value from the terraform configuration file. For instance, the
+example above will expose the timeouts proeprty in the resource_v1 but only for the create and delete operations enablind the
+user to override the default values in the swagger file with different ones:
+
+````
+resource "openapi_resource_v1" "my_resource" {
+  timeouts {
+    create = "10s"
+    delete = "5s"
+  }
+}
+````
+
+Hence overriding the default timeout value set in the swagger file for the ```/v1/resource``` post operation from 15m to 10s
+and the default timeout value set in the swagger file for the ```/v1/resource``` delete operation from 20m to 5s.
 
 *Note: This extension is only supported at the operation level*
 

--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -324,7 +324,7 @@ paths:
 ````
 
 This extension will also enable users to specify a different value from the terraform configuration file. For instance, the
-example above will expose the timeouts proeprty in the resource_v1 but only for the create and delete operations enablind the
+example above will expose the timeouts property in the resource_v1 but only for the create and delete operations enablind the
 user to override the default values in the swagger file with different ones:
 
 ````

--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -336,8 +336,8 @@ resource "openapi_resource_v1" "my_resource" {
 }
 ````
 
-Hence overriding the default timeout value set in the swagger file for the ```/v1/resource``` post operation from 15m to 10s
-and the default timeout value set in the swagger file for the ```/v1/resource``` delete operation from 20m to 5s.
+Hence overriding the default timeout value set in the swagger document for the ```/v1/resource``` post operation from 15m to 10s
+and the default timeout value set in the swagger document for the ```/v1/resource/{id}``` delete operation from 20m to 5s.
 
 *Note: This extension is only supported at the operation level*
 

--- a/tests/integration/resource_lbs_test.go
+++ b/tests/integration/resource_lbs_test.go
@@ -188,10 +188,43 @@ resource "%s" "%s" {
 
 	expectedValidationError, _ := regexp.Compile(".*timeout while waiting for state to become 'deployed' \\(last state: 'deploy_in_progress', timeout: 1s\\).*")
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		IsUnitTest:   true,
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckLBsV1DestroyWithDelay(timeToProcess + 1), // wait long enough so polling timeouts; otherwise
+		PreCheck:   func() { testAccPreCheck(t) },
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		//CheckDestroy: testCheckLBsV1DestroyWithDelay(timeToProcess + 1), // wait long enough so polling timeouts; otherwise
+		Steps: []resource.TestStep{
+			{
+				Config:      testCreateConfigLB,
+				ExpectError: expectedValidationError,
+			},
+		},
+	})
+}
+
+func TestAccLB_UserTriesToSetTimeoutForOperationThatDoesNotSupportIt(t *testing.T) {
+	timeToProcess := 3
+	lb = newLB("some_name", []string{"backend.com"}, timeToProcess, false)
+	testCreateConfigLB = fmt.Sprintf(`provider "%s" {
+  apikey_auth = "apiKeyValue"
+  x_request_id = "some value..."
+}
+
+resource "%s" "%s" {
+  name = "%s"
+  backends = ["%s"]
+  time_to_process = %d # the operation (post,update,delete) will take 15s in the API to complete
+  simulate_failure = %v # no failures wished now ;) (post,update,delete)
+  timeouts {
+    delete = "5s"
+  }
+}`, providerName, openAPIResourceNameLB, openAPIResourceInstanceNameLB, lb.Name, arrayToString(lb.Backends), timeToProcess, lb.SimulateFailure)
+
+	expectedValidationError, _ := regexp.Compile(".*An argument named \"delete\" is not expected here.*")
+	resource.Test(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		//CheckDestroy: testCheckLBsV1DestroyWithDelay(timeToProcess + 1), // wait long enough so polling timeouts; otherwise
 		Steps: []resource.TestStep{
 			{
 				Config:      testCreateConfigLB,

--- a/tests/integration/resource_lbs_test.go
+++ b/tests/integration/resource_lbs_test.go
@@ -31,6 +31,7 @@ func TestAccLB_Create(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
+		IsUnitTest:   true,
 		CheckDestroy: testCheckLBsV1Destroy(),
 		Steps: []resource.TestStep{
 			{
@@ -156,6 +157,39 @@ func TestAccLB_CreateTimeout(t *testing.T) {
 	expectedValidationError, _ := regexp.Compile(".*timeout while waiting for state to become 'deployed' \\(last state: 'deploy_in_progress', timeout: 2s\\).*")
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckLBsV1DestroyWithDelay(timeToProcess + 1), // wait long enough so polling timeouts; otherwise
+		Steps: []resource.TestStep{
+			{
+				Config:      testCreateConfigLB,
+				ExpectError: expectedValidationError,
+			},
+		},
+	})
+}
+
+func TestAccLB_CreateDoesNotTimeoutDueToUserSpecifyingALongerTimeout(t *testing.T) {
+	timeToProcess := 3
+	lb = newLB("some_name", []string{"backend.com"}, timeToProcess, false)
+	testCreateConfigLB = fmt.Sprintf(`provider "%s" {
+  apikey_auth = "apiKeyValue"
+  x_request_id = "some value..."
+}
+
+resource "%s" "%s" {
+  name = "%s"
+  backends = ["%s"]
+  time_to_process = %d # the operation (post,update,delete) will take 15s in the API to complete
+  simulate_failure = %v # no failures wished now ;) (post,update,delete)
+  timeouts {
+    create = "1s"
+  }
+}`, providerName, openAPIResourceNameLB, openAPIResourceInstanceNameLB, lb.Name, arrayToString(lb.Backends), timeToProcess, lb.SimulateFailure)
+
+	expectedValidationError, _ := regexp.Compile(".*timeout while waiting for state to become 'deployed' \\(last state: 'deploy_in_progress', timeout: 1s\\).*")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		IsUnitTest:   true,
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckLBsV1DestroyWithDelay(timeToProcess + 1), // wait long enough so polling timeouts; otherwise
 		Steps: []resource.TestStep{

--- a/tests/integration/resource_lbs_test.go
+++ b/tests/integration/resource_lbs_test.go
@@ -186,7 +186,7 @@ resource "%s" "%s" {
   }
 }`, providerName, openAPIResourceNameLB, openAPIResourceInstanceNameLB, lb.Name, arrayToString(lb.Backends), timeToProcess, lb.SimulateFailure)
 
-	expectedValidationError, _ := regexp.Compile(".*timeout while waiting for state to become 'deployed' \\(last state: 'deploy_in_progress', timeout: 1s\\).*")
+	expectedValidationError, _ := regexp.Compile(".*timeout while waiting for state to become 'deployed' \\((?:last state: 'deploy_pending', )?timeout: 1s\\).*")
 	resource.Test(t, resource.TestCase{
 		PreCheck:   func() { testAccPreCheck(t) },
 		IsUnitTest: true,

--- a/tests/integration/resource_lbs_test.go
+++ b/tests/integration/resource_lbs_test.go
@@ -224,7 +224,6 @@ resource "%s" "%s" {
 		PreCheck:   func() { testAccPreCheck(t) },
 		IsUnitTest: true,
 		Providers:  testAccProviders,
-		//CheckDestroy: testCheckLBsV1DestroyWithDelay(timeToProcess + 1), // wait long enough so polling timeouts; otherwise
 		Steps: []resource.TestStep{
 			{
 				Config:      testCreateConfigLB,

--- a/tests/integration/resource_lbs_test.go
+++ b/tests/integration/resource_lbs_test.go
@@ -168,7 +168,7 @@ func TestAccLB_CreateTimeout(t *testing.T) {
 	})
 }
 
-func TestAccLB_CreateDoesNotTimeoutDueToUserSpecifyingALongerTimeout(t *testing.T) {
+func TestAccLB_CreateDoesNotTimeoutDueToUserSpecifyingAShorterTimeout(t *testing.T) {
 	timeToProcess := 3
 	lb = newLB("some_name", []string{"backend.com"}, timeToProcess, false)
 	testCreateConfigLB = fmt.Sprintf(`provider "%s" {

--- a/tests/integration/resource_lbs_test.go
+++ b/tests/integration/resource_lbs_test.go
@@ -191,7 +191,6 @@ resource "%s" "%s" {
 		PreCheck:   func() { testAccPreCheck(t) },
 		IsUnitTest: true,
 		Providers:  testAccProviders,
-		//CheckDestroy: testCheckLBsV1DestroyWithDelay(timeToProcess + 1), // wait long enough so polling timeouts; otherwise
 		Steps: []resource.TestStep{
 			{
 				Config:      testCreateConfigLB,


### PR DESCRIPTION
## Proposed changes

Add more clear documentation about how timeouts are handled by the open api terraform provider.

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [ ] Bug-fix (change that fixes current functionality)
- [ ] New feature (change that adds new functionality)
- [x] Enhancement

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'make test' locally from the terraform_provider_api folder and no errors were found
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)