### PR TITLE
support provider name with version containing multiple digits (e,g: terraform-provider-openapi_v0.20.0)

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 }
 
 func getProviderName(binaryName string) (string, error) {
-	r, err := regexp.Compile("\\bterraform-provider-([a-zA-Z0-9]+)(?:_v\\d\\.\\d\\.\\d)?\\b")
+	r, err := regexp.Compile("\\bterraform-provider-([a-zA-Z0-9]+)(?:_v[\\d]+\\.[\\d]+\\.[\\d]+)?\\b")
 	if err != nil {
 		return "", err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -31,6 +31,18 @@ func TestGetProviderName(t *testing.T) {
 			})
 		})
 	})
+	Convey("Given a valid pluginName with correct version using multiple digits", t, func() {
+		binaryName := "terraform-provider-goa_v10.34.1"
+		Convey("When getProviderName method is called", func() {
+			providerName, err := getProviderName(binaryName)
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the error message returned should be", func() {
+				So(providerName, ShouldEqual, "goa")
+			})
+		})
+	})
 	Convey("Given a valid pluginName with numbers in the name", t, func() {
 		binaryName := "terraform-provider-goa1234"
 		Convey("When getProviderName method is called", func() {


### PR DESCRIPTION
Enable multiple digits in regex that checks binary name and extracts the provider name

## Proposed changes

Please add as many details as possible about the change here. Does this Pull Request resolve any open issue? If so, please make sure to link to that issue:
                                                              
Fixes: #172 

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [x] Bug-fix (change that fixes current functionality)
- [ ] New feature (change that adds new functionality)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'make test' locally from the terraform_provider_api folder and no errors were found
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)