### PR TITLE
Remove error out when API returns properties that are not specified in the resource definition model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,10 +39,10 @@ require (
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/lint v0.0.0-20190930215403-16217165b5de // indirect
-	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582 // indirect
+	golang.org/x/net v0.0.0-20191021144547-ec77196f6094 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
-	golang.org/x/tools v0.0.0-20191014205221-18e3458ac98b // indirect
+	golang.org/x/sys v0.0.0-20191024172528-b4ff53e7a1cb // indirect
+	golang.org/x/tools v0.0.0-20191024220359-3d91e92cde03 // indirect
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528 // indirect
 	gopkg.in/yaml.v2 v2.2.2

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -88,7 +89,8 @@ func updateStateWithPayloadData(openAPIResource SpecResource, remoteData map[str
 	for propertyName, propertyValue := range remoteData {
 		property, err := resourceSchema.getProperty(propertyName)
 		if err != nil {
-			return fmt.Errorf("failed to update state with remote data. This usually happens when the API returns properties that are not specified in the resource's schema definition in the OpenAPI document - error = %s", err)
+			log.Printf("[WARN] The API returned a property that is not specified in the resource's schema definition in the OpenAPI document - error = %s", err)
+			continue
 		}
 		if property.isPropertyNamedID() {
 			continue

--- a/openapi/common_test.go
+++ b/openapi/common_test.go
@@ -343,8 +343,12 @@ func TestUpdateStateWithPayloadData(t *testing.T) {
 				"some_other_property_not_documented_in_openapi_doc": 15,
 			}
 			err := updateStateWithPayloadData(r.openAPIResource, remoteData, resourceData)
-			Convey("Then the err returned should matched the expected one", func() {
-				So(err.Error(), ShouldEqual, "failed to update state with remote data. This usually happens when the API returns properties that are not specified in the resource's schema definition in the OpenAPI document - error = property with name 'some_other_property_not_documented_in_openapi_doc' not existing in resource schema definition")
+			Convey("Then the err returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("Then the resource state data only contains the properties and values for the documented properties", func() {
+				So(resourceData.Get(stringWithPreferredNameProperty.getTerraformCompliantPropertyName()), ShouldEqual, remoteData[stringWithPreferredNameProperty.Name])
+				So(resourceData.Get("some_other_property_not_documented_in_openapi_doc"), ShouldBeNil)
 			})
 		})
 	})

--- a/openapi/resource_factory.go
+++ b/openapi/resource_factory.go
@@ -389,13 +389,13 @@ func (r resourceFactory) validateImmutableProperty(property *specSchemaDefinitio
 			localList := localData.([]interface{})
 			remoteList := remoteData.([]interface{})
 			if len(localList) != len(remoteList) {
-				return fmt.Errorf("immutable list property '%s' size updated: [input list size: %d; remote list size: %d]", property.Name, len(localList), len(remoteList))
+				return fmt.Errorf("user attempted to update an immutable list property ('%s') size: [user input list size: %d; actual list size: %d]", property.Name, len(localList), len(remoteList))
 			}
 			if isListOfPrimitives, _ := property.isTerraformListOfSimpleValues(); isListOfPrimitives {
 
 				for idx, elem := range localList {
 					if elem != remoteList[idx] {
-						return fmt.Errorf("immutable list property '%s' elements updated: [input: %+v; remote: %+v]", property.Name, localList, remoteList)
+						return fmt.Errorf("user attempted to update an immutable list property ('%s') element: [user input: %+v; actual: %+v]", property.Name, localList, remoteList)
 					}
 				}
 			} else {
@@ -406,7 +406,7 @@ func (r resourceFactory) validateImmutableProperty(property *specSchemaDefinitio
 					for _, objectProp := range property.SpecSchemaDefinition.Properties {
 						err := r.validateImmutableProperty(objectProp, remoteObj[objectProp.Name], localObj[objectProp.Name], property.Immutable)
 						if err != nil {
-							return fmt.Errorf("immutable list of objects '%s' updated: [input: %s; remote: %s]", property.Name, localData, remoteData)
+							return fmt.Errorf("user attempted to update an immutable list of objects ('%s'): [user input: %s; actual: %s]", property.Name, localData, remoteData)
 						}
 					}
 				}
@@ -418,7 +418,7 @@ func (r resourceFactory) validateImmutableProperty(property *specSchemaDefinitio
 		for _, objProp := range property.SpecSchemaDefinition.Properties {
 			err := r.validateImmutableProperty(objProp, remoteObject[objProp.Name], localObject[objProp.Name], property.Immutable)
 			if err != nil {
-				return fmt.Errorf("immutable object '%s' property '%s' value updated: [input: %s; remote: %s]", property.Name, objProp.Name, localData, remoteData)
+				return fmt.Errorf("user attempted to update an immutable object ('%s') property ('%s'): [user input: %s; actual: %s]", property.Name, objProp.Name, localData, remoteData)
 			}
 		}
 	default:
@@ -427,18 +427,18 @@ func (r resourceFactory) validateImmutableProperty(property *specSchemaDefinitio
 			case float64: // this is due to the json marshalling always mapping ints to float64d
 				if property.Type == typeFloat {
 					if localData != remoteData {
-						return fmt.Errorf("immutable float property '%s' value updated: [input: %s; remote: %s]", property.Name, localData, remoteData)
+						return fmt.Errorf("user attempted to update an immutable float property ('%s'): [user input: %s; actual: %s]", property.Name, localData, remoteData)
 					}
 				} else {
 					if property.Type == typeInt {
 						if localData != int(remoteData.(float64)) {
-							return fmt.Errorf("immutable integer property '%s' value updated: [input: %d; remote: %d]", property.Name, localData, int(remoteData.(float64)))
+							return fmt.Errorf("user attempted to update an immutable integer property ('%s'): [user input: %d; actual: %d]", property.Name, localData, int(remoteData.(float64)))
 						}
 					}
 				}
 			default:
 				if localData != remoteData {
-					return fmt.Errorf("immutable property '%s' value updated: [input: %s; remote: %s]", property.Name, localData, remoteData)
+					return fmt.Errorf("user attempted to update an immutable property ('%s'): [user input: %s; actual: %s]", property.Name, localData, remoteData)
 				}
 			}
 		}

--- a/openapi/resource_factory_test.go
+++ b/openapi/resource_factory_test.go
@@ -371,7 +371,7 @@ func TestUpdate(t *testing.T) {
 				So(err, ShouldNotBeNil)
 			})
 			Convey("And the error returned should equal ", func() {
-				So(err.Error(), ShouldEqual, "validation for immutable properties failed: immutable property 'string_immutable_property' value updated: [input: updatedImmutableValue; remote: immutableOriginalValue]. Update operation was aborted; no updates were performed")
+				So(err.Error(), ShouldEqual, "validation for immutable properties failed: user attempted to update an immutable property ('string_immutable_property'): [user input: updatedImmutableValue; actual: immutableOriginalValue]. Update operation was aborted; no updates were performed")
 			})
 			Convey("And resourceData values should be the values got from the response payload (original values)", func() {
 				So(resourceData.Id(), ShouldEqual, idProperty.Default)
@@ -1066,7 +1066,7 @@ func TestCheckImmutableFields(t *testing.T) {
 			assertions: func(resourceData *schema.ResourceData) {
 				assert.Equal(t, "originalImmutablePropertyValue", resourceData.Get("immutable_prop"))
 			},
-			expectedError: errors.New("validation for immutable properties failed: immutable property 'immutable_prop' value updated: [input: updatedImmutableValue; remote: originalImmutablePropertyValue]. Update operation was aborted; no updates were performed"),
+			expectedError: errors.New("validation for immutable properties failed: user attempted to update an immutable property ('immutable_prop'): [user input: updatedImmutableValue; actual: originalImmutablePropertyValue]. Update operation was aborted; no updates were performed"),
 		},
 		{
 			name: "immutable int property is updated",
@@ -1084,7 +1084,7 @@ func TestCheckImmutableFields(t *testing.T) {
 			assertions: func(resourceData *schema.ResourceData) {
 				assert.Equal(t, 6, resourceData.Get("immutable_prop"))
 			},
-			expectedError: errors.New("validation for immutable properties failed: immutable integer property 'immutable_prop' value updated: [input: 4; remote: 6]. Update operation was aborted; no updates were performed"),
+			expectedError: errors.New("validation for immutable properties failed: user attempted to update an immutable integer property ('immutable_prop'): [user input: 4; actual: 6]. Update operation was aborted; no updates were performed"),
 		},
 		{
 			name: "immutable int property has not changed",
@@ -1120,7 +1120,7 @@ func TestCheckImmutableFields(t *testing.T) {
 			assertions: func(resourceData *schema.ResourceData) {
 				assert.Equal(t, 3.8, resourceData.Get("immutable_prop"))
 			},
-			expectedError: errors.New("validation for immutable properties failed: immutable float property 'immutable_prop' value updated: [input: %!s(float64=4.5); remote: %!s(float64=3.8)]. Update operation was aborted; no updates were performed"),
+			expectedError: errors.New("validation for immutable properties failed: user attempted to update an immutable float property ('immutable_prop'): [user input: %!s(float64=4.5); actual: %!s(float64=3.8)]. Update operation was aborted; no updates were performed"),
 		},
 		{
 			name: "immutable float property has not changed",
@@ -1156,7 +1156,7 @@ func TestCheckImmutableFields(t *testing.T) {
 			assertions: func(resourceData *schema.ResourceData) {
 				assert.Equal(t, false, resourceData.Get("immutable_prop"))
 			},
-			expectedError: errors.New("validation for immutable properties failed: immutable property 'immutable_prop' value updated: [input: %!s(bool=true); remote: %!s(bool=false)]. Update operation was aborted; no updates were performed"),
+			expectedError: errors.New("validation for immutable properties failed: user attempted to update an immutable property ('immutable_prop'): [user input: %!s(bool=true); actual: %!s(bool=false)]. Update operation was aborted; no updates were performed"),
 		},
 		{
 			name: "immutable list property is updated",
@@ -1175,7 +1175,7 @@ func TestCheckImmutableFields(t *testing.T) {
 			assertions: func(resourceData *schema.ResourceData) {
 				assert.Equal(t, []interface{}{"value1", "value2"}, resourceData.Get("immutable_prop"))
 			},
-			expectedError: errors.New("validation for immutable properties failed: immutable list property 'immutable_prop' elements updated: [input: [value1Updated value2Updated]; remote: [value1 value2]]. Update operation was aborted; no updates were performed"),
+			expectedError: errors.New("validation for immutable properties failed: user attempted to update an immutable list property ('immutable_prop') element: [user input: [value1Updated value2Updated]; actual: [value1 value2]]. Update operation was aborted; no updates were performed"),
 		},
 		{
 			name: "mutable list property is updated",
@@ -1213,7 +1213,7 @@ func TestCheckImmutableFields(t *testing.T) {
 			assertions: func(resourceData *schema.ResourceData) {
 				assert.Equal(t, []interface{}{"value1", "value2"}, resourceData.Get("immutable_prop"))
 			},
-			expectedError: errors.New("validation for immutable properties failed: immutable list property 'immutable_prop' size updated: [input list size: 3; remote list size: 2]. Update operation was aborted; no updates were performed"),
+			expectedError: errors.New("validation for immutable properties failed: user attempted to update an immutable list property ('immutable_prop') size: [user input list size: 3; actual list size: 2]. Update operation was aborted; no updates were performed"),
 		},
 		{
 			name: "immutable object property is updated",
@@ -1242,7 +1242,7 @@ func TestCheckImmutableFields(t *testing.T) {
 			assertions: func(resourceData *schema.ResourceData) {
 				assert.Equal(t, map[string]interface{}{"origin_port": "443", "protocol": "https", "read_only_property": "some_value"}, resourceData.Get("immutable_prop"))
 			},
-			expectedError: errors.New("validation for immutable properties failed: immutable object 'immutable_prop' property 'origin_port' value updated: [input: map[origin_port:%!s(int64=80) protocol:http]; remote: map[origin_port:%!s(float64=443) protocol:https read_only_property:some_value]]. Update operation was aborted; no updates were performed"),
+			expectedError: errors.New("validation for immutable properties failed: user attempted to update an immutable object ('immutable_prop') property ('origin_port'): [user input: map[origin_port:%!s(int64=80) protocol:http]; actual: map[origin_port:%!s(float64=443) protocol:https read_only_property:some_value]]. Update operation was aborted; no updates were performed"),
 		},
 		{
 			name: "mutable object properties are updated",
@@ -1300,7 +1300,7 @@ func TestCheckImmutableFields(t *testing.T) {
 			assertions: func(resourceData *schema.ResourceData) {
 				assert.Equal(t, map[string]interface{}{"origin_port": "443", "protocol": "https", "string_immutable_property": "some_value"}, resourceData.Get("mutable_prop"))
 			},
-			expectedError: errors.New("validation for immutable properties failed: immutable object 'mutable_prop' property 'string_immutable_property' value updated: [input: map[origin_port:%!s(int64=80) protocol:http string_immutable_property:updatedImmutableValue]; remote: map[origin_port:%!s(float64=443) protocol:https string_immutable_property:some_value]]. Update operation was aborted; no updates were performed"),
+			expectedError: errors.New("validation for immutable properties failed: user attempted to update an immutable object ('mutable_prop') property ('string_immutable_property'): [user input: map[origin_port:%!s(int64=80) protocol:http string_immutable_property:updatedImmutableValue]; actual: map[origin_port:%!s(float64=443) protocol:https string_immutable_property:some_value]]. Update operation was aborted; no updates were performed"),
 		},
 		{
 			name: "immutable object with nested object property is updated",
@@ -1335,7 +1335,7 @@ func TestCheckImmutableFields(t *testing.T) {
 			assertions: func(resourceData *schema.ResourceData) {
 				assert.Equal(t, []interface{}{map[string]interface{}{"object_property": map[string]interface{}{"some_prop": "someValue"}}}, resourceData.Get("immutable_prop"))
 			},
-			expectedError: errors.New("validation for immutable properties failed: immutable object 'immutable_prop' property 'object_property' value updated: [input: map[object_property:map[some_prop:someUpdatedValue]]; remote: map[object_property:map[some_prop:someValue]]]. Update operation was aborted; no updates were performed"),
+			expectedError: errors.New("validation for immutable properties failed: user attempted to update an immutable object ('immutable_prop') property ('object_property'): [user input: map[object_property:map[some_prop:someUpdatedValue]]; actual: map[object_property:map[some_prop:someValue]]]. Update operation was aborted; no updates were performed"),
 		},
 		{
 			name: "immutable list of objects is updated",
@@ -1365,7 +1365,7 @@ func TestCheckImmutableFields(t *testing.T) {
 			assertions: func(resourceData *schema.ResourceData) {
 				assert.Equal(t, []interface{}{map[string]interface{}{"origin_port": 443, "protocol": "https"}}, resourceData.Get("immutable_prop"))
 			},
-			expectedError: errors.New("validation for immutable properties failed: immutable list of objects 'immutable_prop' updated: [input: [map[origin_port:%!s(int=80) protocol:http]]; remote: [map[origin_port:%!s(float64=443) protocol:https]]]. Update operation was aborted; no updates were performed"),
+			expectedError: errors.New("validation for immutable properties failed: user attempted to update an immutable list of objects ('immutable_prop'): [user input: [map[origin_port:%!s(int=80) protocol:http]]; actual: [map[origin_port:%!s(float64=443) protocol:https]]]. Update operation was aborted; no updates were performed"),
 		},
 		{
 			name: "mutable list of objects where some properties are immutable and values are not updated",
@@ -1439,7 +1439,7 @@ func TestCheckImmutableFields(t *testing.T) {
 			expectedError: errors.New("some error"),
 		},
 		{
-			name: "immutable property is updated and the client returned more properties than the ones specified in the schema",
+			name: "immutable property is updated",
 			inputProps: []*specSchemaDefinitionProperty{
 				{
 					Name:      "immutable_prop",
@@ -1455,7 +1455,7 @@ func TestCheckImmutableFields(t *testing.T) {
 				},
 			},
 			assertions:    func(resourceData *schema.ResourceData) {},
-			expectedError: errors.New("failed to update state with remote data. This usually happens when the API returns properties that are not specified in the resource's schema definition in the OpenAPI document - error = property with name 'unknown_prop' not existing in resource schema definition"),
+			expectedError: errors.New("validation for immutable properties failed: user attempted to update an immutable property ('immutable_prop'): [user input: updatedImmutableValue; actual: originalImmutablePropertyValue]. Update operation was aborted; no updates were performed"),
 		},
 	}
 

--- a/tests/integration/resource_cdns_test.go
+++ b/tests/integration/resource_cdns_test.go
@@ -648,7 +648,7 @@ func TestAccCDN_CreateWithZeroValues(t *testing.T) {
 
 func TestAccCDN_UpdateImmutableProperty(t *testing.T) {
 	testCDNUpdatedImmutableConfig := populateTemplateConfigurationCDN("label updated", cdn.Ips, cdn.Hostnames, cdn.ExampleInt, cdn.ExampleNumber, cdn.ExampleBoolean, cdn.ObjectNestedSchemeProperty.ObjectProperty.Account, cdn.ObjectProperty.Message, cdn.ObjectProperty.DetailedMessage, cdn.ArrayOfObjectsExample[0].Protocol, cdn.ArrayOfObjectsExample[0].OriginPort, cdn.ArrayOfObjectsExample[1].Protocol, cdn.ArrayOfObjectsExample[1].OriginPort)
-	expectedValidationError, _ := regexp.Compile("errors during apply: validation for immutable properties failed: immutable property 'label' value updated: \\[input: label updated; remote: someLabel\\]. Update operation was aborted; no updates were performed")
+	expectedValidationError, _ := regexp.Compile("errors during apply: validation for immutable properties failed: user attempted to update an immutable property \\('label'\\): \\[user input: label updated; actual: someLabel\\]. Update operation was aborted; no updates were performed")
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,


### PR DESCRIPTION
## Proposed changes

Please add as many details as possible about the change here. Does this Pull Request resolve any open issue? If so, please make sure to link to that issue:
                                                              
Fixes: #169 

Also updated the immutable properties error messaging to be more readable.

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [x] Bug-fix (change that fixes current functionality)
- [ ] New feature (change that adds new functionality)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'make test' locally from the terraform_provider_api folder and no errors were found
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)