### PR TITLE
[bug-fix] Do not fail when schema property configuration (defined in openapi config file) command exec fails or source file to get default value from does not exists

### DIFF
--- a/docs/plugin_configuration_schema.md
+++ b/docs/plugin_configuration_schema.md
@@ -81,10 +81,10 @@ Describes the schema configuration for the service provider:
 Field Name | Type | Description
 ---|:---:|---
 schema_property_name | `string` | Defines the name of the provider's schema property. For more info refer to [OpenAPI Provider Configuration](https://github.com/dikhan/terraform-provider-openapi/blob/master/docs/using_openapi_provider.md#configuration)
-cmd | `[]string` | Defines the command to execute (using exec form: ```["executable","param1","param2"]```) before the value is assigned to the schema property. This command can be used for example to refresh non static tokens before the value is assigned. Note, there must be at least one value in the array for the cmd to be executed.
+cmd | `[]string` | Defines the command to execute (using exec form: ```["executable","param1","param2"]```) before the value is assigned to the schema property. This command can be used for example to refresh non static tokens before the value is assigned. Note, there must be at least one value in the array for the cmd to be executed. If the command fails to execute, the plugin will log the error and continue its execution.
 cmd_timeout | `int` | Defines the max timeout, in seconds, for the command to execute. If the timeout is not specified the default value is 10s.
 default_value | `string` | Defines the default value for the property. If ```schema_property_external_configuration``` is defined, it takes preference over this value.
-schema_property_external_configuration | [Schema Property External Configuration Object](https://github.com/dikhan/terraform-provider-openapi/blob/master/docs/plugin_configuration_schema.md#schema-property-external-configuration) | Schema Property External Configuration Object
+schema_property_external_configuration | [Schema Property External Configuration Object](https://github.com/dikhan/terraform-provider-openapi/blob/master/docs/plugin_configuration_schema.md#schema-property-external-configuration) | Schema Property External Configuration Object. If there is an error when retriving the info from the external source, the plugin will log the error and continue its execution and will set the default value as empty ultimately delegating the responsibility to the API to complain about any missing required property. 
 
 ##### Schema Property External Configuration Object
 

--- a/go.mod
+++ b/go.mod
@@ -37,13 +37,13 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/stretchr/testify v1.3.0
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea // indirect
-	golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c // indirect
+	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 // indirect
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
-	golang.org/x/net v0.0.0-20191125084936-ffdde1057850 // indirect
+	golang.org/x/net v0.0.0-20191206103017-1ddd1de85cb0 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/sys v0.0.0-20191126131656-8a8471f7e56d // indirect
-	golang.org/x/tools v0.0.0-20191126055441-b0650ceb63d9 // indirect
-	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
+	golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e // indirect
+	golang.org/x/tools v0.0.0-20191205225056-3393d29bb9fe // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -39,10 +39,10 @@ require (
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea // indirect
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 // indirect
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
-	golang.org/x/net v0.0.0-20191206103017-1ddd1de85cb0 // indirect
+	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e // indirect
-	golang.org/x/tools v0.0.0-20191206202126-6d582d504c7b // indirect
+	golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab // indirect
+	golang.org/x/tools v0.0.0-20191206204035-259af5ff87bd // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528 // indirect
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	golang.org/x/net v0.0.0-20191206103017-1ddd1de85cb0 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e // indirect
-	golang.org/x/tools v0.0.0-20191205225056-3393d29bb9fe // indirect
+	golang.org/x/tools v0.0.0-20191206202126-6d582d504c7b // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528 // indirect
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.mod
+++ b/go.mod
@@ -41,8 +41,8 @@ require (
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab // indirect
-	golang.org/x/tools v0.0.0-20191206204035-259af5ff87bd // indirect
+	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect
+	golang.org/x/tools v0.0.0-20191209225234-22774f7dae43 // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528 // indirect
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,8 @@ golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f h1:kz4KIr+xcPUsI3VMoqWfPM
 golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c h1:/nJuwDLoL/zrqY6gf57vxC+Pi+pZ8bfhpPkicO5H7W4=
 golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
+golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -349,6 +351,8 @@ golang.org/x/net v0.0.0-20191118183410-d06c31c94cae h1:AzDIJnLFoW3GaQvpbMRKk+Spt
 golang.org/x/net v0.0.0-20191118183410-d06c31c94cae/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191125084936-ffdde1057850 h1:Vq85/r8R9IdcUHmZ0/nQlUg1v15rzvQ2sHdnZAj/x7s=
 golang.org/x/net v0.0.0-20191125084936-ffdde1057850/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191206103017-1ddd1de85cb0 h1:LxY/gQN/MrcW24/46nLyiip1GhN/Yi14QPbeNskTvQA=
+golang.org/x/net v0.0.0-20191206103017-1ddd1de85cb0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 h1:Wo7BWFiOk0QRFMLYMqJGFMd9CgUAcGx7V+qEg/h5IBI=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -381,6 +385,7 @@ golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191118133127-cf1e2d577169/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191126131656-8a8471f7e56d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -417,8 +422,11 @@ golang.org/x/tools v0.0.0-20191118222007-07fc4c7f2b98/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191126055441-b0650ceb63d9 h1:m9xhlkk2j+sO9WjAgNfTtl505MN7ZkuW69nOcBlp9qY=
 golang.org/x/tools v0.0.0-20191126055441-b0650ceb63d9/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191205225056-3393d29bb9fe h1:BEVcKURC7E0EF+vD1l52Jb3LOM5Iwu7OI5FpdPuU50o=
+golang.org/x/tools v0.0.0-20191205225056-3393d29bb9fe/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/go.sum
+++ b/go.sum
@@ -353,6 +353,8 @@ golang.org/x/net v0.0.0-20191125084936-ffdde1057850 h1:Vq85/r8R9IdcUHmZ0/nQlUg1v
 golang.org/x/net v0.0.0-20191125084936-ffdde1057850/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191206103017-1ddd1de85cb0 h1:LxY/gQN/MrcW24/46nLyiip1GhN/Yi14QPbeNskTvQA=
 golang.org/x/net v0.0.0-20191206103017-1ddd1de85cb0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
+golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 h1:Wo7BWFiOk0QRFMLYMqJGFMd9CgUAcGx7V+qEg/h5IBI=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -386,6 +388,7 @@ golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191118133127-cf1e2d577169/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191126131656-8a8471f7e56d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -426,6 +429,8 @@ golang.org/x/tools v0.0.0-20191205225056-3393d29bb9fe h1:BEVcKURC7E0EF+vD1l52Jb3
 golang.org/x/tools v0.0.0-20191205225056-3393d29bb9fe/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191206202126-6d582d504c7b h1:YzOnUydn3Gob6mZEpLqHiHvvpBMiGSts3kzZbpGEouw=
 golang.org/x/tools v0.0.0-20191206202126-6d582d504c7b/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191206204035-259af5ff87bd h1:Zc7EU2PqpsNeIfOoVA7hvQX4cS3YDJEs5KlfatT3hLo=
+golang.org/x/tools v0.0.0-20191206204035-259af5ff87bd/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -389,6 +389,7 @@ golang.org/x/sys v0.0.0-20191118133127-cf1e2d577169/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191126131656-8a8471f7e56d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -431,6 +432,8 @@ golang.org/x/tools v0.0.0-20191206202126-6d582d504c7b h1:YzOnUydn3Gob6mZEpLqHiHv
 golang.org/x/tools v0.0.0-20191206202126-6d582d504c7b/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191206204035-259af5ff87bd h1:Zc7EU2PqpsNeIfOoVA7hvQX4cS3YDJEs5KlfatT3hLo=
 golang.org/x/tools v0.0.0-20191206204035-259af5ff87bd/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191209225234-22774f7dae43 h1:NfPq5mgc5ArFgVLCpeS4z07IoxSAqVfV/gQ5vxdgaxI=
+golang.org/x/tools v0.0.0-20191209225234-22774f7dae43/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -424,6 +424,8 @@ golang.org/x/tools v0.0.0-20191126055441-b0650ceb63d9 h1:m9xhlkk2j+sO9WjAgNfTtl5
 golang.org/x/tools v0.0.0-20191126055441-b0650ceb63d9/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191205225056-3393d29bb9fe h1:BEVcKURC7E0EF+vD1l52Jb3LOM5Iwu7OI5FpdPuU50o=
 golang.org/x/tools v0.0.0-20191205225056-3393d29bb9fe/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191206202126-6d582d504c7b h1:YzOnUydn3Gob6mZEpLqHiHvvpBMiGSts3kzZbpGEouw=
+golang.org/x/tools v0.0.0-20191206202126-6d582d504c7b/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/openapi/plugin_config.go
+++ b/openapi/plugin_config.go
@@ -42,7 +42,7 @@ func NewPluginConfiguration(providerName string) (*PluginConfiguration, error) {
 		return nil, err
 	}
 	if _, err := os.Stat(configurationFilePath); os.IsNotExist(err) {
-		log.Printf("[INFO] open api plugin configuration not present at %s", configurationFilePath)
+		return nil, fmt.Errorf("open api plugin configuration not present at %s", configurationFilePath)
 	} else {
 		log.Printf("[INFO] found open api plugin configuration at %s", configurationFilePath)
 		file, err := os.Open(configurationFilePath)

--- a/openapi/plugin_config.go
+++ b/openapi/plugin_config.go
@@ -42,14 +42,15 @@ func NewPluginConfiguration(providerName string) (*PluginConfiguration, error) {
 		return nil, err
 	}
 	if _, err := os.Stat(configurationFilePath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("open api plugin configuration not present at %s", configurationFilePath)
+		log.Printf("[INFO] open api plugin configuration not present at %s", configurationFilePath)
+	} else {
+		log.Printf("[INFO] found open api plugin configuration at %s", configurationFilePath)
+		file, err := os.Open(configurationFilePath)
+		if err != nil {
+			return nil, err
+		}
+		configurationFile = bufio.NewReader(file)
 	}
-	log.Printf("[INFO] found open api plugin configuration at %s", configurationFilePath)
-	file, err := os.Open(configurationFilePath)
-	if err != nil {
-		return nil, err
-	}
-	configurationFile = bufio.NewReader(file)
 	return &PluginConfiguration{
 		ProviderName:  providerName,
 		Configuration: configurationFile,

--- a/openapi/plugin_config.go
+++ b/openapi/plugin_config.go
@@ -43,14 +43,13 @@ func NewPluginConfiguration(providerName string) (*PluginConfiguration, error) {
 	}
 	if _, err := os.Stat(configurationFilePath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("open api plugin configuration not present at %s", configurationFilePath)
-	} else {
-		log.Printf("[INFO] found open api plugin configuration at %s", configurationFilePath)
-		file, err := os.Open(configurationFilePath)
-		if err != nil {
-			return nil, err
-		}
-		configurationFile = bufio.NewReader(file)
 	}
+	log.Printf("[INFO] found open api plugin configuration at %s", configurationFilePath)
+	file, err := os.Open(configurationFilePath)
+	if err != nil {
+		return nil, err
+	}
+	configurationFile = bufio.NewReader(file)
 	return &PluginConfiguration{
 		ProviderName:  providerName,
 		Configuration: configurationFile,

--- a/openapi/plugin_config_services_schema_property_configuration.go
+++ b/openapi/plugin_config_services_schema_property_configuration.go
@@ -77,7 +77,7 @@ func (s ServiceSchemaPropertyConfigurationV1) ExecuteCommand() error {
 	go s.exec(doneChan)
 	err := <-doneChan
 	if err != nil {
-		return err
+		return fmt.Errorf("provider schema property '%s' command failed: %s", s.SchemaPropertyName, err)
 	}
 	return nil
 }
@@ -115,7 +115,7 @@ func (s ServiceSchemaPropertyConfigurationV1) exec(doneChan chan error) {
 
 		// If there's no context error, we know the command completed (or errored).
 		if err != nil {
-			doneChan <- fmt.Errorf("failed to execute '%s' command '%s': %s(%s)", s.SchemaPropertyName, s.Command, stderr.String(), err)
+			doneChan <- fmt.Errorf("command '%s' failed: %s(%s)", s.Command, stderr.String(), err)
 			return
 		}
 		log.Printf("[INFO] provider schema property '%s' command '%s' executed successfully (time:%s): %s", s.SchemaPropertyName, s.Command, time.Since(start), stdout.String())

--- a/openapi/plugin_config_services_schema_property_configuration_test.go
+++ b/openapi/plugin_config_services_schema_property_configuration_test.go
@@ -238,6 +238,32 @@ func TestServiceSchemaConfigurationV1GetDefaultValue(t *testing.T) {
 			})
 		})
 	})
+
+	Convey("Given an external config file and a ServiceSchemaPropertyConfigurationV1 with an external configuration pointing a json file but the keyName is wrong", t, func() {
+		expectedValue := "someName"
+		tmpFile, err := ioutil.TempFile("", "")
+		defer os.Remove(tmpFile.Name())
+		So(err, ShouldBeNil)
+		tmpFile.Write([]byte(fmt.Sprintf(`{"firstName":"%s"}`, expectedValue)))
+		serviceSchemaConfigurationV1 := ServiceSchemaPropertyConfigurationV1{
+			SchemaPropertyName: "schemaPropertyName",
+			DefaultValue:       "defaultValue",
+			ExternalConfiguration: ServiceSchemaPropertyExternalConfigurationV1{
+				KeyName:     "$.wrong",
+				ContentType: "json",
+				File:        tmpFile.Name(),
+			},
+		}
+		Convey("When GetDefaultValue method is called", func() {
+			_, err := serviceSchemaConfigurationV1.GetDefaultValue()
+			Convey("And the err returned should NOT be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the err message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "key error: wrong not found in object")
+			})
+		})
+	})
 }
 
 func TestServiceExternalConfigurationV1GetFileParser(t *testing.T) {

--- a/openapi/plugin_config_services_schema_property_configuration_test.go
+++ b/openapi/plugin_config_services_schema_property_configuration_test.go
@@ -54,7 +54,7 @@ func TestServiceSchemaConfigurationV1ExecuteCommand(t *testing.T) {
 				So(err, ShouldNotBeNil)
 			})
 			Convey("And the err message returned should be the expected", func() {
-				So(err.Error(), ShouldEqual, "failed to execute 'some_property_name' command '[cat nonexistingfile]': cat: nonexistingfile: No such file or directory\n(exit status 1)")
+				So(err.Error(), ShouldEqual, "provider schema property 'some_property_name' command failed: command '[cat nonexistingfile]' failed: cat: nonexistingfile: No such file or directory\n(exit status 1)")
 			})
 		})
 	})
@@ -70,7 +70,7 @@ func TestServiceSchemaConfigurationV1ExecuteCommand(t *testing.T) {
 				So(err, ShouldNotBeNil)
 			})
 			Convey("And the err message returned should be the expected", func() {
-				So(err.Error(), ShouldEqual, "command '[sleep 2]' did not finish executing within the expected time 1s (signal: killed)")
+				So(err.Error(), ShouldEqual, "provider schema property 'some_property_name' command failed: command '[sleep 2]' did not finish executing within the expected time 1s (signal: killed)")
 			})
 		})
 	})
@@ -104,7 +104,7 @@ func TestServiceSchemaConfigurationV1Exec(t *testing.T) {
 				So(err, ShouldNotBeNil)
 			})
 			Convey("And the err message returned should be the expected", func() {
-				So(err.Error(), ShouldEqual, "failed to execute 'some_property_name' command '[cat nonexistingfile]': cat: nonexistingfile: No such file or directory\n(exit status 1)")
+				So(err.Error(), ShouldEqual, "command '[cat nonexistingfile]' failed: cat: nonexistingfile: No such file or directory\n(exit status 1)")
 			})
 		})
 	})

--- a/openapi/plugin_config_services_schema_property_configuration_test.go
+++ b/openapi/plugin_config_services_schema_property_configuration_test.go
@@ -154,7 +154,6 @@ func TestServiceSchemaConfigurationV1GetDefaultValue(t *testing.T) {
 			SchemaPropertyName: "schemaPropertyName",
 			DefaultValue:       "defaultValue",
 			ExternalConfiguration: ServiceSchemaPropertyExternalConfigurationV1{
-				//KeyName:     "someKeyName",
 				ContentType: "raw",
 				File:        tmpFile.Name(),
 			},
@@ -216,6 +215,26 @@ func TestServiceSchemaConfigurationV1GetDefaultValue(t *testing.T) {
 			})
 			Convey("And the err message should be", func() {
 				So(err.Error(), ShouldContainSubstring, "'schemaPropertyName': 'nonSupported' content type not supported")
+			})
+		})
+	})
+
+	Convey("Given an external config file and a ServiceSchemaPropertyConfigurationV1 with an external configuration pointing a non existing file", t, func() {
+		serviceSchemaConfigurationV1 := ServiceSchemaPropertyConfigurationV1{
+			SchemaPropertyName: "schemaPropertyName",
+			DefaultValue:       "defaultValue",
+			ExternalConfiguration: ServiceSchemaPropertyExternalConfigurationV1{
+				ContentType: "nonSupported",
+				File:        "som_non_existing_file",
+			},
+		}
+		Convey("When GetDefaultValue method is called", func() {
+			_, err := serviceSchemaConfigurationV1.GetDefaultValue()
+			Convey("And the err returned should NOT be nil", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("And the err message should be", func() {
+				So(err.Error(), ShouldContainSubstring, "failed to read external configuration file 'som_non_existing_file' for schema property 'schemaPropertyName': open som_non_existing_file: no such file or directory")
 			})
 		})
 	})

--- a/openapi/plugin_config_services_stub.go
+++ b/openapi/plugin_config_services_stub.go
@@ -17,6 +17,7 @@ type ServiceSchemaPropertyConfigurationStub struct {
 	SchemaPropertyName   string
 	DefaultValue         string
 	Err                  error
+	GetDefaultValueFunc  func() (string, error)
 	ExecuteCommandCalled bool
 }
 
@@ -52,6 +53,9 @@ func (s ServiceConfigStub) GetSchemaPropertyConfiguration(schemaPropertyName str
 
 // GetDefaultValue returns the dafult value configured in the ServiceSchemaPropertyConfigurationStub.defaultValue field
 func (s *ServiceSchemaPropertyConfigurationStub) GetDefaultValue() (string, error) {
+	if s.GetDefaultValueFunc != nil {
+		return s.GetDefaultValueFunc()
+	}
 	return s.DefaultValue, nil
 }
 

--- a/openapi/provider_factory_test.go
+++ b/openapi/provider_factory_test.go
@@ -372,10 +372,12 @@ func TestCreateTerraformProviderSchema(t *testing.T) {
 			SchemaConfiguration: []*ServiceSchemaPropertyConfigurationStub{
 				{
 					SchemaPropertyName:   "apikey_auth",
+					DefaultValue:         "someDefaultAuthToken",
 					ExecuteCommandCalled: false,
 				},
 				{
 					SchemaPropertyName:   "header_name",
+					DefaultValue:         "someDefaultHeaderValue",
 					ExecuteCommandCalled: false,
 				},
 			},
@@ -417,6 +419,16 @@ func TestCreateTerraformProviderSchema(t *testing.T) {
 			Convey("And the provider schema properties commands should have been executed", func() {
 				So(serviceConfig.SchemaConfiguration[0].ExecuteCommandCalled, ShouldBeTrue)
 				So(serviceConfig.SchemaConfiguration[1].ExecuteCommandCalled, ShouldBeTrue)
+			})
+			Convey("And the provider schema 'apikey_auth' property default value should be the expected default", func() {
+				defaultValue, err := providerSchema[apiKeyAuthProperty.Name].DefaultFunc()
+				So(err, ShouldBeNil)
+				So(defaultValue, ShouldEqual, "someDefaultAuthToken")
+			})
+			Convey("And the provider schema 'header_name' property default value should be the expected default", func() {
+				defaultValue, err := providerSchema[headerProperty.Name].DefaultFunc()
+				So(err, ShouldBeNil)
+				So(defaultValue, ShouldEqual, "someDefaultHeaderValue")
 			})
 		})
 	})
@@ -466,8 +478,8 @@ func TestCreateTerraformProviderSchema(t *testing.T) {
 	})
 
 	Convey("Given a provider factory that is configured with security definitions that are not all part of the global schemes", t, func() {
-		var globalSecurityDefinitionName = "apiKeyAuth"
-		var otherSecurityDefinitionName = "otherSecurityDefinitionName"
+		var globalSecurityDefinitionName = "api_key_auth"
+		var otherSecurityDefinitionName = "other_security_definition_name"
 		p := providerFactory{
 			name: "provider",
 			specAnalyser: &specAnalyserStub{
@@ -493,18 +505,18 @@ func TestCreateTerraformProviderSchema(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 			Convey("And the provider schema for the resource should contain the expected attributes with names automatically converted to be compliant", func() {
-				So(providerSchema, ShouldContainKey, "api_key_auth")
-				So(providerSchema, ShouldContainKey, "other_security_definition_name")
+				So(providerSchema, ShouldContainKey, globalSecurityDefinitionName)
+				So(providerSchema, ShouldContainKey, otherSecurityDefinitionName)
 			})
 			Convey("And the api_key_auth should be required as it's a global scheme", func() {
-				So(providerSchema["api_key_auth"].Required, ShouldBeTrue)
+				So(providerSchema[globalSecurityDefinitionName].Required, ShouldBeTrue)
 			})
 			Convey("And the other_security_definition_name should be optional as it's not referred in the global schemes", func() {
-				So(providerSchema["other_security_definition_name"].Optional, ShouldBeTrue)
+				So(providerSchema[otherSecurityDefinitionName].Optional, ShouldBeTrue)
 			})
 			Convey("And the provider schema default function for all the properties", func() {
-				So(providerSchema["api_key_auth"].DefaultFunc, ShouldNotBeNil)
-				So(providerSchema["other_security_definition_name"].DefaultFunc, ShouldNotBeNil)
+				So(providerSchema[globalSecurityDefinitionName].DefaultFunc, ShouldNotBeNil)
+				So(providerSchema[otherSecurityDefinitionName].DefaultFunc, ShouldNotBeNil)
 			})
 		})
 	})

--- a/tests/integration/provider_plugin_configuration_test.go
+++ b/tests/integration/provider_plugin_configuration_test.go
@@ -366,7 +366,7 @@ services:
       cmd: ['date']
       schema_property_external_configuration:
         content_type: json
-        key_name: $.apikey_auth
+        key_name: $.wrong_name
         file: %s`, apiKeyAuthFile.Name())
 	file := createPluginConfigFile(testPluginConfig)
 	defer os.Remove(file.Name())

--- a/tests/integration/provider_plugin_configuration_test.go
+++ b/tests/integration/provider_plugin_configuration_test.go
@@ -336,7 +336,7 @@ func TestAccProviderConfiguration_PluginExternalFile_NotFound(t *testing.T) {
 	initPluginWithExternalConfigFile("/some/non/existing/path")
 	p := &openapi.ProviderOpenAPI{ProviderName: providerName}
 	_, err := p.CreateSchemaProvider()
-	if !strings.Contains(err.Error(), "swagger url not provided, please export OTF_VAR_<provider_name>_SWAGGER_URL env variable with the URL where 'openapi' service provider is exposing the swagger file OR create a plugin configuration file at ~/.terraform.d/plugins following the Plugin configuration schema specifications") {
+	if !strings.Contains(err.Error(), "plugin init error: open api plugin configuration not present at /some/non/existing/path") {
 		log.Fatalf("test failed, non expected output: %s", err)
 	}
 }

--- a/tests/integration/provider_plugin_configuration_test.go
+++ b/tests/integration/provider_plugin_configuration_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/dikhan/terraform-provider-openapi/openapi"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/stretchr/testify/assert"
 	"log"
 	"os"
 	"strings"
@@ -305,9 +306,7 @@ services:
 
 	p := &openapi.ProviderOpenAPI{ProviderName: providerName}
 	_, err := p.CreateSchemaProvider()
-	if !strings.Contains(err.Error(), "plugin terraform-provider-openapi init error while creating schema provider: failed to execute 'apikey_auth' command '[cat nonExistingFile]': cat: nonExistingFile: No such file or directory") {
-		log.Fatalf("test failed, non expected output: %s", err)
-	}
+	assert.NoError(t, err)
 	os.Unsetenv(otfVarPluginConfigEnvVariableName)
 }
 
@@ -326,9 +325,55 @@ services:
 	initPluginWithExternalConfigFile(file.Name())
 	p := &openapi.ProviderOpenAPI{ProviderName: providerName}
 	_, err := p.CreateSchemaProvider()
-	if !strings.Contains(err.Error(), "plugin terraform-provider-openapi init error while creating schema provider: command '[sleep 2]' did not finish executing within the expected time 1s") {
-		log.Fatalf("test failed, non expected output: %s", err)
-	}
+	assert.NoError(t, err)
+	os.Unsetenv(otfVarPluginConfigEnvVariableName)
+}
+
+func TestAccProviderConfiguration_PluginExternalFile_SchemaProperty_ExternalConfiguration_FileNotExists(t *testing.T) {
+	testPluginConfig := fmt.Sprintf(`version: '1'
+services:
+  openapi:
+    swagger-url: https://localhost:8443/swagger.yaml
+    insecure_skip_verify: true
+    schema_configuration:
+    - schema_property_name: "apikey_auth"
+      cmd: ['date']
+      schema_property_external_configuration:
+        content_type: json
+        key_name: $.apikey_auth
+        file: /path_to_non_existing_file.json`)
+	file := createPluginConfigFile(testPluginConfig)
+	defer os.Remove(file.Name())
+	initPluginWithExternalConfigFile(file.Name())
+	p := &openapi.ProviderOpenAPI{ProviderName: providerName}
+	_, err := p.CreateSchemaProvider()
+	assert.NoError(t, err)
+	os.Unsetenv(otfVarPluginConfigEnvVariableName)
+}
+
+func TestAccProviderConfiguration_PluginExternalFile_SchemaProperty_ExternalConfiguration_FileKeyNameWrong(t *testing.T) {
+	apiKeyAuthFileContentJSON := `{"apikey_auth":"apiKeyValue"}`
+	apiKeyAuthFile := createPluginConfigFile(apiKeyAuthFileContentJSON)
+	defer os.Remove(apiKeyAuthFile.Name())
+
+	testPluginConfig := fmt.Sprintf(`version: '1'
+services:
+  openapi:
+    swagger-url: https://localhost:8443/swagger.yaml
+    insecure_skip_verify: true
+    schema_configuration:
+    - schema_property_name: "apikey_auth"
+      cmd: ['date']
+      schema_property_external_configuration:
+        content_type: json
+        key_name: $.apikey_auth
+        file: %s`, apiKeyAuthFile.Name())
+	file := createPluginConfigFile(testPluginConfig)
+	defer os.Remove(file.Name())
+	initPluginWithExternalConfigFile(file.Name())
+	p := &openapi.ProviderOpenAPI{ProviderName: providerName}
+	_, err := p.CreateSchemaProvider()
+	assert.NoError(t, err)
 	os.Unsetenv(otfVarPluginConfigEnvVariableName)
 }
 

--- a/tests/integration/provider_plugin_configuration_test.go
+++ b/tests/integration/provider_plugin_configuration_test.go
@@ -381,7 +381,7 @@ func TestAccProviderConfiguration_PluginExternalFile_NotFound(t *testing.T) {
 	initPluginWithExternalConfigFile("/some/non/existing/path")
 	p := &openapi.ProviderOpenAPI{ProviderName: providerName}
 	_, err := p.CreateSchemaProvider()
-	if !strings.Contains(err.Error(), "plugin init error: open api plugin configuration not present at /some/non/existing/path") {
+	if !strings.Contains(err.Error(), "swagger url not provided, please export OTF_VAR_<provider_name>_SWAGGER_URL env variable with the URL where 'openapi' service provider is exposing the swagger file OR create a plugin configuration file at ~/.terraform.d/plugins following the Plugin configuration schema specifications") {
 		log.Fatalf("test failed, non expected output: %s", err)
 	}
 }


### PR DESCRIPTION
## Proposed changes

Please add as many details as possible about the change here. Does this Pull Request resolve any open issue? If so, please make sure to link to that issue:
                                                              
Fixes: #190  

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) 
in the boxes that apply:

- [x] Bug-fix (change that fixes current functionality)
- [ ] New feature (change that adds new functionality)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have made sure code compiles correctly
- [x] I have run 'make test' locally from the terraform_provider_api folder and no errors were found
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated necessary documentation (if appropriate)