### PR TITLE
Add support for x-ignore-order

### DIFF
--- a/openapi/openapi_v2_resource.go
+++ b/openapi/openapi_v2_resource.go
@@ -58,6 +58,7 @@ const extTfID = "x-terraform-id"
 const extTfComputed = "x-terraform-computed"
 const extTfComplexObjectType = "x-terraform-complex-object-legacy-config"
 const extTfIgnoreOrder = "x-terraform-ignore-order"
+const extIgnoreOrder = "x-ignore-order"
 
 // Operation level extensions
 const extTfResourceTimeout = "x-terraform-resource-timeout"
@@ -392,7 +393,7 @@ func (o *SpecV2Resource) createSchemaDefinitionProperty(propertyName string, pro
 		schemaDefinitionProperty.ArrayItemsType = itemsType
 		schemaDefinitionProperty.SpecSchemaDefinition = itemsSchema // only diff than nil if type is object
 
-		if o.isBoolExtensionEnabled(property.Extensions, extTfIgnoreOrder) {
+		if o.isBoolExtensionEnabled(property.Extensions, extTfIgnoreOrder) || o.isBoolExtensionEnabled(property.Extensions, extIgnoreOrder) {
 			schemaDefinitionProperty.IgnoreItemsOrder = true
 		}
 

--- a/openapi/openapi_v2_resource_test.go
+++ b/openapi/openapi_v2_resource_test.go
@@ -2496,6 +2496,34 @@ func TestCreateSchemaDefinitionProperty(t *testing.T) {
 			})
 		})
 
+		Convey("When createSchemaDefinitionProperty is called with a property schema that has the 'x-ignore-order' extension", func() {
+			expectedIgnoreOrder := true
+			propertySchema := spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type: spec.StringOrArray{"array"},
+					Items: &spec.SchemaOrArray{
+						Schema: &spec.Schema{
+							SchemaProps: spec.SchemaProps{
+								Type: spec.StringOrArray{"string"},
+							},
+						},
+					},
+				},
+				VendorExtensible: spec.VendorExtensible{
+					Extensions: spec.Extensions{
+						extIgnoreOrder: expectedIgnoreOrder,
+					},
+				},
+			}
+			schemaDefinitionProperty, err := r.createSchemaDefinitionProperty("propertyName", propertySchema, []string{})
+			Convey("Then the error returned should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the schema definition property should have the IgnoreItemsOrder field enabled", func() {
+				So(schemaDefinitionProperty.IgnoreItemsOrder, ShouldEqual, expectedIgnoreOrder)
+			})
+		})
+
 		Convey("When createSchemaDefinitionProperty is called with a property schema that has the 'x-terraform-field-status' extension", func() {
 			expectedIsStatusFieldValue := true
 			propertySchema := spec.Schema{


### PR DESCRIPTION
## What problem does this Pull Request solve?

Please link to the issue number here: #233 

P.S: Intentionally not making the PR title a feature request as it is not desired for this change to be outlined in the next release change-log. 

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] New feature (change that adds new functionality)
- [ ] Bug-fix (change that fixes current functionality)
- [ ] Tech debt (enhances the current functionality)
- [ ] New release (pumps the version)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made sure code compiles correctly and all tests are passing by running `make test-all`
- [x] I have added/updated necessary documentation (if appropriate)
- [x] I have added the following info to the title of the PR (pick the appropriate option for the type of change). This is important because the release notes will include this information.
  - [ ] Feature Request: PRs related to feature requests should have in the title `[FeatureRequest: Issue #X] <PR Title>`
  - [ ] Bug Fixes: PRs related to bug fixes should have in the title `[BugFix: Issue #X] <PR Title>`
  - [ ] Tech Debt: PRs related to technical debt should have in the title `[TechDebt: Issue #X] <PR Title>` 
  - [ ] New Release: PRs related to a new release should have in the title `[NewRelease] vX.Y.Z`

## Checklist for Admins
- [x] Label is populated
- [x] PR is assigned to the corresponding project
- [x] PR has at least 1 reviewer and 1 assignee