### PR TITLE
Render in arguments section optional computed properties with default values

### DIFF
--- a/openapi/openapi_spec_resource_schema_definition_property.go
+++ b/openapi/openapi_spec_resource_schema_definition_property.go
@@ -149,6 +149,13 @@ func (s *SpecSchemaDefinitionProperty) IsOptionalComputed() bool {
 	return s.isOptional() && !s.isReadOnly() && s.Computed && s.Default == nil
 }
 
+// IsOptionalComputedWithDefault returns true for properties that are optional and a value (known at plan time) is computed by the API
+// if the client does not provide a value. In order for a property to be considered optional computed it must meet:
+// - The property must be optional, not readOnly (computed) and must have a default value populated
+func (s *SpecSchemaDefinitionProperty) IsOptionalComputedWithDefault() bool {
+	return s.isOptional() && !s.isReadOnly() && s.Computed && s.Default != nil
+}
+
 func (s *SpecSchemaDefinitionProperty) terraformType() (schema.ValueType, error) {
 	switch s.Type {
 	case TypeString:

--- a/openapi/openapi_spec_resource_schema_definition_property_test.go
+++ b/openapi/openapi_spec_resource_schema_definition_property_test.go
@@ -541,6 +541,79 @@ func TestSchemaDefinitionPropertyIsOptionalComputed(t *testing.T) {
 	})
 }
 
+func TestSchemaDefinitionPropertyIsOptionalComputedWithDefault(t *testing.T) {
+	Convey("Given a property that is optional, not readOnly, is computed and does not have a default value (optional-computed property where value is not known at plan time)", t, func() {
+		s := &SpecSchemaDefinitionProperty{
+			Type:     TypeString,
+			Required: false,
+			ReadOnly: false,
+			Computed: true,
+			Default:  nil,
+		}
+		Convey("When IsOptionalComputedWithDefault method is called", func() {
+			isOptionalComputedWithDefault := s.IsOptionalComputedWithDefault()
+			Convey("Then value returned should be true", func() {
+				So(isOptionalComputedWithDefault, ShouldBeFalse)
+			})
+		})
+	})
+	Convey("Given a property that is not optional", t, func() {
+		s := &SpecSchemaDefinitionProperty{
+			Type:     TypeString,
+			Required: true,
+		}
+		Convey("When IsOptionalComputedWithDefault method is called", func() {
+			isOptionalComputedWithDefault := s.IsOptionalComputedWithDefault()
+			Convey("Then value returned should be true", func() {
+				So(isOptionalComputedWithDefault, ShouldBeFalse)
+			})
+		})
+	})
+	Convey("Given a property that is optional but readOnly", t, func() {
+		s := &SpecSchemaDefinitionProperty{
+			Type:     TypeString,
+			Required: false,
+			ReadOnly: true,
+		}
+		Convey("When IsOptionalComputedWithDefault method is called", func() {
+			isOptionalComputedWithDefault := s.IsOptionalComputedWithDefault()
+			Convey("Then value returned should be true", func() {
+				So(isOptionalComputedWithDefault, ShouldBeFalse)
+			})
+		})
+	})
+	Convey("Given a property that is optional, not readOnly and it's not computed (purely optional use case)", t, func() {
+		s := &SpecSchemaDefinitionProperty{
+			Type:     TypeString,
+			Required: false,
+			ReadOnly: false,
+			Computed: false,
+			Default:  nil,
+		}
+		Convey("When IsOptionalComputedWithDefault method is called", func() {
+			isOptionalComputedWithDefault := s.IsOptionalComputedWithDefault()
+			Convey("Then value returned should be true", func() {
+				So(isOptionalComputedWithDefault, ShouldBeFalse)
+			})
+		})
+	})
+	Convey("Given a property that is optional, not readOnly, computed and has a default value (optional-computed use case, but as far as terraform is concerned the default will be set on the terraform schema (unless it's a type list which is not supported), making it available at plan time - this is by design in terraform)", t, func() {
+		s := &SpecSchemaDefinitionProperty{
+			Type:     TypeString,
+			Required: false,
+			ReadOnly: false,
+			Computed: true,
+			Default:  "something",
+		}
+		Convey("When IsOptionalComputedWithDefault method is called", func() {
+			isOptionalComputedWithDefault := s.IsOptionalComputedWithDefault()
+			Convey("Then value returned should be true", func() {
+				So(isOptionalComputedWithDefault, ShouldBeTrue)
+			})
+		})
+	})
+}
+
 func TestTerraformType(t *testing.T) {
 	Convey("Given a swagger schema definition that has a property of type string", t, func() {
 		s := &SpecSchemaDefinitionProperty{

--- a/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_provider_doc_generator.go
+++ b/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_provider_doc_generator.go
@@ -259,10 +259,11 @@ func (t TerraformProviderDocGenerator) resourceSchemaToProperty(specSchemaDefini
 		ArrayItemsType:     string(specSchemaDefinitionProperty.ArrayItemsType),
 		Required:           specSchemaDefinitionProperty.IsRequired(),
 		Computed:           specSchemaDefinitionProperty.Computed,
-		IsOptionalComputed: specSchemaDefinitionProperty.IsOptionalComputed(),
+		IsOptionalComputed: specSchemaDefinitionProperty.IsOptionalComputed() || specSchemaDefinitionProperty.IsOptionalComputedWithDefault(),
 		IsSensitive:        specSchemaDefinitionProperty.Sensitive,
 		IsParent:           specSchemaDefinitionProperty.IsParentProperty,
 		Description:        specSchemaDefinitionProperty.Description,
+		Default:            specSchemaDefinitionProperty.Default,
 		Schema:             orderProps(schema),
 	}
 }

--- a/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_provider_doc_generator_test.go
+++ b/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_provider_doc_generator_test.go
@@ -495,8 +495,8 @@ func TestGetDataSourceFilters(t *testing.T) {
 					Type: openapi.TypeObject,
 					SpecSchemaDefinition: &openapi.SpecSchemaDefinition{
 						Properties: openapi.SpecSchemaDefinitionProperties{
-							{Name: "string_prop2", Type: openapi.TypeString},
 							{Name: "string_prop3", Type: openapi.TypeString},
+							{Name: "string_prop2", Type: openapi.TypeString},
 							{Name: "string_prop1", Type: openapi.TypeString},
 						},
 					},
@@ -510,8 +510,8 @@ func TestGetDataSourceFilters(t *testing.T) {
 					Computed:           true,
 					IsOptionalComputed: true,
 					Schema: []Property{
-						{Name: "string_prop3", Type: "string", Required: false, Computed: true, IsOptionalComputed: true},
 						{Name: "string_prop1", Type: "string", Required: false, Computed: true, IsOptionalComputed: true},
+						{Name: "string_prop3", Type: "string", Required: false, Computed: true, IsOptionalComputed: true},
 						{Name: "string_prop2", Type: "string", Required: false, Computed: true, IsOptionalComputed: true},
 					},
 				},
@@ -626,8 +626,8 @@ func TestGetDataSourceInstances(t *testing.T) {
 					Computed:           true,
 					IsOptionalComputed: true,
 					Schema: []Property{
-						{Name: "string_prop3", Type: "string", Required: false, Computed: true, IsOptionalComputed: true},
 						{Name: "string_prop1", Type: "string", Required: false, Computed: true, IsOptionalComputed: true},
+						{Name: "string_prop3", Type: "string", Required: false, Computed: true, IsOptionalComputed: true},
 						{Name: "string_prop2", Type: "string", Required: false, Computed: true, IsOptionalComputed: true},
 					},
 				},
@@ -741,8 +741,8 @@ func TestGetProviderResources(t *testing.T) {
 					Required: false,
 					Computed: false,
 					Schema: []Property{
-						{Name: "string_prop3", Type: "string", Required: false, Computed: false},
 						{Name: "string_prop1", Type: "string", Required: false, Computed: false},
+						{Name: "string_prop3", Type: "string", Required: false, Computed: false},
 						{Name: "string_prop2", Type: "string", Required: false, Computed: false},
 					},
 				},
@@ -947,9 +947,9 @@ func TestOrderProps(t *testing.T) {
 	}
 	orderedProps := orderProps(inputProps)
 	expectedProps := []Property{
-		{Name: "prop2"},
-		{Name: "prop1"},
 		{Name: "prop3"},
+		{Name: "prop1"},
+		{Name: "prop2"},
 	}
 	assert.Equal(t, expectedProps, orderedProps)
 }

--- a/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_provider_documentation_properties.go
+++ b/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_provider_documentation_properties.go
@@ -11,6 +11,7 @@ type Property struct {
 	IsSensitive        bool
 	IsParent           bool
 	Description        string
+	Default            interface{}
 	Schema             []Property // This is used to describe the schema for array of objects or object properties
 }
 

--- a/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_provider_documentation_properties.go
+++ b/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_provider_documentation_properties.go
@@ -24,3 +24,8 @@ func (p Property) ContainsComputedSubProperties() bool {
 	}
 	return false
 }
+
+// DefaultNotNil checks whether the Default value is nil. If the value is populated it returns true, false otherwise
+func (p Property) DefaultNotNil() bool {
+	return p.Default != nil
+}

--- a/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_provider_documentation_properties_test.go
+++ b/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_provider_documentation_properties_test.go
@@ -51,3 +51,28 @@ func TestProperty_ContainsComputedSubProperties(t *testing.T) {
 		assert.Equal(t, tc.expectedResult, result)
 	}
 }
+
+func TestProperty_DefaultNotNil(t *testing.T) {
+	testCases := []struct {
+		name           string
+		property       Property
+		expectedResult bool
+	}{
+		{
+			name:           "property does not contain a default value",
+			expectedResult: false,
+		},
+		{
+			name: "property does contain a default value",
+			property: Property{
+				Name:    "some property with schema (eg: object or array of objects) containing computed props",
+				Default: "some value",
+			},
+			expectedResult: true,
+		},
+	}
+	for _, tc := range testCases {
+		result := tc.property.DefaultNotNil()
+		assert.Equal(t, tc.expectedResult, result)
+	}
+}

--- a/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_template_html.go
+++ b/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_template_html.go
@@ -290,7 +290,7 @@ var ArgumentReferenceTmpl = `{{- define "resource_argument_reference" -}}
         {{- $required = "Required" -}}
     {{end}}
 	{{- if or .Required (and (not .Required) (not .Computed)) .IsOptionalComputed -}}
-    <li>{{if eq .Type "object"}}<span class="wysiwyg-color-red">*</span>{{end}} {{.Name}} [{{.Type}} {{- if eq .Type "list" }} of {{.ArrayItemsType}}s{{- end -}}] {{- if .IsSensitive -}}(<a href="#special_terms_definitions_sensitive_property" target="_self">sensitive</a>){{- end}} - ({{$required}}) {{if .IsParent}}The {{.Name}} that this resource belongs to{{else}}{{.Description}}{{end}}
+    <li>{{if eq .Type "object"}}<span class="wysiwyg-color-red">*</span>{{end}} {{.Name}} [{{.Type}} {{- if eq .Type "list" }} of {{.ArrayItemsType}}s{{- end -}}] {{- if .IsSensitive -}}(<a href="#special_terms_definitions_sensitive_property" target="_self">sensitive</a>){{- end}} - ({{$required}}) {{if .IsParent}}The {{.Name}} that this resource belongs to{{else}}{{.Description}}{{- if .Default -}}. Default value is: {{.Default}}{{- end -}}{{end}}
         {{- if or (eq .Type "object") (eq .ArrayItemsType "object")}}. The following properties compose the object schema
         :<ul dir="ltr">
             {{- range .Schema}}

--- a/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_template_html.go
+++ b/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_template_html.go
@@ -290,7 +290,7 @@ var ArgumentReferenceTmpl = `{{- define "resource_argument_reference" -}}
         {{- $required = "Required" -}}
     {{end}}
 	{{- if or .Required (and (not .Required) (not .Computed)) .IsOptionalComputed -}}
-    <li>{{if eq .Type "object"}}<span class="wysiwyg-color-red">*</span>{{end}} {{.Name}} [{{.Type}} {{- if eq .Type "list" }} of {{.ArrayItemsType}}s{{- end -}}] {{- if .IsSensitive -}}(<a href="#special_terms_definitions_sensitive_property" target="_self">sensitive</a>){{- end}} - ({{$required}}) {{if .IsParent}}The {{.Name}} that this resource belongs to{{else}}{{.Description}}{{- if .Default -}}. Default value is: {{.Default}}{{- end -}}{{end}}
+    <li>{{if eq .Type "object"}}<span class="wysiwyg-color-red">*</span>{{end}} {{.Name}} [{{.Type}} {{- if eq .Type "list" }} of {{.ArrayItemsType}}s{{- end -}}] {{- if .IsSensitive -}}(<a href="#special_terms_definitions_sensitive_property" target="_self">sensitive</a>){{- end}} - ({{$required}}) {{if .IsParent}}The {{.Name}} that this resource belongs to{{else}}{{.Description}}{{- if .DefaultNotNil -}}. Default value is: {{.Default}}{{- end -}}{{end}}
         {{- if or (eq .Type "object") (eq .ArrayItemsType "object")}}. The following properties compose the object schema
         :<ul dir="ltr">
             {{- range .Schema}}

--- a/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_template_html_test.go
+++ b/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_template_html_test.go
@@ -72,6 +72,31 @@ func TestArgumentReferenceTmpl(t *testing.T) {
 			expectedOutput: "<li> optional_computed_prop [string] - (Optional) this is an optional computed property</li>\n\t",
 		},
 		{
+			name:           "optional computed property with default value",
+			property:       Property{Name: "optional_computed_prop", Type: "string", Description: "this is an optional computed property", IsOptionalComputed: true, Default: "some default value"},
+			expectedOutput: "<li> optional_computed_prop [string] - (Optional) this is an optional computed property. Default value is: some default value</li>\n\t",
+		},
+		{
+			name:           "optional computed property int with default value",
+			property:       Property{Name: "optional_computed_prop", Type: "integer", Description: "this is an optional computed property", IsOptionalComputed: true, Default: 26},
+			expectedOutput: "<li> optional_computed_prop [integer] - (Optional) this is an optional computed property. Default value is: 26</li>\n\t",
+		},
+		{
+			name:           "optional computed property bool with default value",
+			property:       Property{Name: "optional_computed_prop", Type: "boolean", Description: "this is an optional computed property", IsOptionalComputed: true, Default: true},
+			expectedOutput: "<li> optional_computed_prop [boolean] - (Optional) this is an optional computed property. Default value is: true</li>\n\t",
+		},
+		{
+			name:           "optional computed property float with default value",
+			property:       Property{Name: "optional_computed_prop", Type: "number", Description: "this is an optional computed property", IsOptionalComputed: true, Default: 12.99},
+			expectedOutput: "<li> optional_computed_prop [number] - (Optional) this is an optional computed property. Default value is: 12.99</li>\n\t",
+		},
+		{
+			name:           "optional computed property list with default value",
+			property:       Property{Name: "optional_computed_prop", Type: "list", ArrayItemsType: "string", Description: "this is an optional computed property", IsOptionalComputed: true, Default: []string{""}},
+			expectedOutput: "<li> optional_computed_prop [list of strings] - (Optional) this is an optional computed property. Default value is: []</li>\n\t",
+		},
+		{
 			name:           "optional property",
 			property:       Property{Name: "optional_prop", Type: "string", Description: "this is an optional property", Required: false},
 			expectedOutput: "<li> optional_prop [string] - (Optional) this is an optional property</li>\n\t",

--- a/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_template_html_test.go
+++ b/pkg/terraformdocsgenerator/openapiterraformdocsgenerator/openapi_terraform_template_html_test.go
@@ -87,13 +87,18 @@ func TestArgumentReferenceTmpl(t *testing.T) {
 			expectedOutput: "<li> optional_computed_prop [boolean] - (Optional) this is an optional computed property. Default value is: true</li>\n\t",
 		},
 		{
+			name:           "optional computed property bool with default value false",
+			property:       Property{Name: "optional_computed_prop", Type: "boolean", Description: "this is an optional computed property", IsOptionalComputed: true, Default: false},
+			expectedOutput: "<li> optional_computed_prop [boolean] - (Optional) this is an optional computed property. Default value is: false</li>\n\t",
+		},
+		{
 			name:           "optional computed property float with default value",
 			property:       Property{Name: "optional_computed_prop", Type: "number", Description: "this is an optional computed property", IsOptionalComputed: true, Default: 12.99},
 			expectedOutput: "<li> optional_computed_prop [number] - (Optional) this is an optional computed property. Default value is: 12.99</li>\n\t",
 		},
 		{
 			name:           "optional computed property list with default value",
-			property:       Property{Name: "optional_computed_prop", Type: "list", ArrayItemsType: "string", Description: "this is an optional computed property", IsOptionalComputed: true, Default: []string{""}},
+			property:       Property{Name: "optional_computed_prop", Type: "list", ArrayItemsType: "string", Description: "this is an optional computed property", IsOptionalComputed: true, Default: []string{}},
 			expectedOutput: "<li> optional_computed_prop [list of strings] - (Optional) this is an optional computed property. Default value is: []</li>\n\t",
 		},
 		{


### PR DESCRIPTION
## What problem does this Pull Request solve?

terraformdocsgenerator does not render optional computed properties with default values in the arguments section

- Added helper method IsOptionalComputedWithDefault to check within the renderer
whether the property with default value is to be treated as optional computed too.
- Renderer now includes both optioanl computed properties and optioanl computed properties
with default values in the arguments section along with the default value if populated.
- Other tests were failing due to ordering not matching anymore. This is due to
the hashstructure.Hash now computing the new property added which changed the hash order.

Please link to the issue number here (issue will be closed when PR is merged): Closes #289 

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [ ] New feature (change that adds new functionality)
- [x] Bug-fix (change that fixes current functionality)
- [ ] Tech debt (enhances the current functionality)
- [ ] New release (pumps the version)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made sure code compiles correctly and all tests are passing by running `make test-all`
- [x] I have added/updated necessary documentation (if appropriate)
- [x] I have added the following info to the title of the PR (pick the appropriate option for the type of change). This is important because the release notes will include this information.
  - [ ] Feature Request: PRs related to feature requests should have in the title `[FeatureRequest: Issue #X] <PR Title>`
  - [x] Bug Fixes: PRs related to bug fixes should have in the title `[BugFix: Issue #X] <PR Title>`
  - [ ] Tech Debt: PRs related to technical debt should have in the title `[TechDebt: Issue #X] <PR Title>` 
  - [ ] New Release: PRs related to a new release should have in the title `[NewRelease] vX.Y.Z`

## Checklist for Admins
- [x] Label is populated
- [x] PR is assigned to the corresponding project
- [x] PR has at least 1 reviewer and 1 assignee