### PR TITLE
[BugFix: Issue #335] goreleaser latest version (1.7) introduced breaking changes requiring Go1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - TF_VERSION=0.13.6 PERFORM_DOCKER_LOGIN=true GO111MODULE=on
 
 install:
-  - go install github.com/goreleaser/goreleaser@latest
+  - go install github.com/goreleaser/goreleaser@v1.6.3
   - wget https://releases.hashicorp.com/terraform/"$TF_VERSION"/terraform_"$TF_VERSION"_linux_amd64.zip
   - unzip terraform_"$TF_VERSION"_linux_amd64.zip
   - sudo mv terraform /usr/local/bin/


### PR DESCRIPTION
## What problem does this Pull Request solve?

Please link to the issue number here (issue will be closed when PR is merged): Closes #335

- Pinning to v1.6.3 until the repo supports Go 1.18
                                                              
*If you don't have an issue created, please create the issue first describing the problem and then open the PR*

## Test

- gorelease installation works as expected and the version is pinned to the expected version:

```
$ go install github.com/goreleaser/goreleaser@v1.6.3
go: downloading github.com/goreleaser/goreleaser v1.6.3
go: downloading github.com/alecthomas/jsonschema v0.0.0-20211209230136-e2b41affa5c1
go: downloading github.com/apex/log v1.9.0
go: downloading github.com/caarlos0/ctrlc v1.0.0
go: downloading github.com/fatih/color v1.13.0
go: downloading github.com/muesli/coral v1.0.0
go: downloading github.com/muesli/mango-coral v1.0.1
go: downloading github.com/muesli/roff v0.1.0
go: downloading github.com/iancoleman/orderedmap v0.2.0
go: downloading github.com/mattn/go-colorable v0.1.12
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/mattn/go-isatty v0.0.14
go: downloading github.com/goreleaser/nfpm/v2 v2.14.0
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading github.com/cpuguy83/go-md2man/v2 v2.0.1
go: downloading github.com/spf13/pflag v1.0.5
go: downloading github.com/muesli/mango v0.1.0
go: downloading github.com/muesli/mango-pflag v0.1.0
go: downloading code.gitea.io/sdk/gitea v0.15.1
go: downloading github.com/google/go-github/v43 v43.0.0
go: downloading github.com/xanzy/go-gitlab v0.56.0
go: downloading github.com/Masterminds/semver v1.5.0
go: downloading github.com/Masterminds/semver/v3 v3.1.1
go: downloading golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
go: downloading github.com/goreleaser/fileglob v1.3.0
go: downloading golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838
go: downloading github.com/caarlos0/go-shellwords v1.0.12
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading github.com/imdario/mergo v0.3.12
go: downloading golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a
go: downloading github.com/russross/blackfriday/v2 v2.1.0
go: downloading github.com/hashicorp/go-version v1.3.0
go: downloading github.com/google/go-querystring v1.1.0
go: downloading github.com/hashicorp/go-cleanhttp v0.5.2
go: downloading github.com/hashicorp/go-retryablehttp v0.7.0
go: downloading golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11
go: downloading gocloud.dev v0.24.0
go: downloading github.com/DisgoOrg/disgohook v1.4.4
go: downloading github.com/caarlos0/env/v6 v6.9.1
go: downloading github.com/caarlos0/go-reddit/v3 v3.0.1
go: downloading github.com/slack-go/slack v0.10.2
go: downloading gopkg.in/mail.v2 v2.3.1
go: downloading github.com/atc0005/go-teams-notify/v2 v2.6.1
go: downloading github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
go: downloading github.com/dghubble/go-twitter v0.0.0-20211115160449-93a8679adecb
go: downloading github.com/dghubble/oauth1 v0.7.1
go: downloading github.com/gobwas/glob v0.2.3
go: downloading golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
go: downloading github.com/AlekSi/pointer v1.2.0
go: downloading github.com/goreleaser/chglog v0.1.2
go: downloading gopkg.in/yaml.v3 v3.0.0-20210107192922-[496]()545a6307b
go: downloading github.com/klauspost/pgzip v1.2.5
go: downloading github.com/blakesmith/ar v0.0.0-20190[502]()131153-809d4375e1fb
go: downloading github.com/ulikunitz/xz v0.5.10
go: downloading github.com/google/rpmpack v0.0.0-2021112[506]()4518-d0ed9b1b61b9
go: downloading github.com/Azure/azure-pipeline-go v0.2.3
go: downloading github.com/Azure/azure-storage-blob-go v0.14.0
go: downloading github.com/Azure/go-autorest v14.2.0+incompatible
go: downloading github.com/Azure/go-autorest/autorest v0.11.23
go: downloading github.com/Azure/go-autorest/autorest/adal v0.9.18
go: downloading github.com/google/uuid v1.3.0
go: downloading github.com/google/wire v0.5.0
go: downloading go.opencensus.io v0.23.0
go: downloading github.com/aws/aws-sdk-go v1.42.24
go: downloading cloud.google.com/go v0.99.0
go: downloading cloud.google.com/go/storage v1.18.2
go: downloading github.com/googleapis/gax-go/v2 v2.1.1
go: downloading google.golang.org/api v0.63.0
go: downloading google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
go: downloading github.com/aws/aws-sdk-go-v2 v1.11.2
go: downloading github.com/aws/aws-sdk-go-v2/service/kms v1.11.1
go: downloading github.com/aws/smithy-go v1.9.0
go: downloading cloud.google.com/go/kms v1.1.0
go: downloading github.com/Azure/azure-sdk-for-go v60.2.0+incompatible
go: downloading google.golang.org/grpc v1.43.0
go: downloading github.com/Azure/go-autorest/autorest/azure/auth v0.5.10
go: downloading github.com/DisgoOrg/log v1.1.2
go: downloading github.com/DisgoOrg/restclient v1.2.8
go: downloading golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
go: downloading github.com/gorilla/websocket v1.4.2
go: downloading github.com/cenkalti/backoff/v4 v4.1.2
go: downloading github.com/dghubble/sling v1.4.0
go: downloading github.com/technoweenie/multipartstreamer v1.0.1
go: downloading github.com/Masterminds/sprig v2.22.0+incompatible
go: downloading github.com/go-git/go-git/v5 v5.4.2
go: downloading github.com/ProtonMail/go-crypto v0.0.0-20210512092938-c05353c2d58c
go: downloading github.com/klauspost/compress v1.13.6
go: downloading github.com/cavaliergopher/cpio v1.0.1
go: downloading github.com/mattn/go-ieproxy v0.0.1
go: downloading github.com/Azure/go-autorest/autorest/date v0.3.0
go: downloading github.com/Azure/go-autorest/logger v0.2.1
go: downloading github.com/Azure/go-autorest/tracing v0.6.0
go: downloading github.com/golang-jwt/jwt/v4 v4.2.0
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading github.com/aws/aws-sdk-go-v2/config v1.11.0
go: downloading github.com/golang/protobuf v1.5.2
go: downloading google.golang.org/protobuf v1.27.1
go: downloading github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.2
go: downloading github.com/Azure/go-autorest/autorest/azure/cli v0.4.4
go: downloading github.com/dimchansky/utfbom v1.1.1
go: downloading github.com/Masterminds/goutils v1.1.1
go: downloading github.com/huandu/xstrings v1.3.2
go: downloading github.com/mitchellh/copystructure v1.2.0
go: downloading github.com/go-git/go-billy/v5 v5.3.1
go: downloading github.com/sergi/go-diff v1.2.0
go: downloading github.com/emirpasic/gods v1.12.0
go: downloading github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
go: downloading github.com/jmespath/go-jmespath v0.4.0
go: downloading github.com/aws/aws-sdk-go-v2/credentials v1.6.4
go: downloading github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.8.2
go: downloading github.com/aws/aws-sdk-go-v2/internal/ini v1.3.2
go: downloading github.com/aws/aws-sdk-go-v2/service/sso v1.6.2
go: downloading github.com/aws/aws-sdk-go-v2/service/sts v1.11.1
go: downloading github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.0.2
go: downloading github.com/mitchellh/reflectwalk v1.0.2
go: downloading github.com/jbenet/go-context v0.0.0-201[507]()11004[518]()-d14ea06fba99
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.5.2
go: downloading github.com/google/go-cmp v0.5.7
go: downloading github.com/go-git/gcfg v1.5.0
go: downloading github.com/kevinburke/ssh_config v1.1.0
go: downloading github.com/xanzy/ssh-agent v0.3.1
go: downloading golang.org/x/text v0.3.7
go: downloading gopkg.in/warnings.v0 v0.1.2
go: downloading github.com/Azure/go-autorest/autorest/to v0.4.0
go: downloading github.com/Azure/go-autorest/autorest/validation v0.3.1
```

The pipeline is failing due to another bug related to the make test-all which is fixed as part of https://github.com/dikhan/terraform-provider-openapi/pull/336. Since this PR only fixed the gorelease part and it's working again and the failure in the pipeline is unrelated to this change will go ahead and merge the PR to unblock the other pending PRs (https://github.com/dikhan/terraform-provider-openapi/pull/332 and https://github.com/dikhan/terraform-provider-openapi/pull/336).

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [ ] New feature (change that adds new functionality)
- [ ] Bug-fix (change that fixes current functionality)
- [x] Tech debt (enhances the current functionality)
- [ ] New release (pumps the version)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made sure code compiles correctly and all tests are passing by running `make test-all`
- [x] I have added/updated necessary documentation (if appropriate)
- [x] I have added the following info to the title of the PR (pick the appropriate option for the type of change). This is important because the release notes will include this information.
  - [ ] Feature Request: PRs related to feature requests should have in the title `[FeatureRequest: Issue #X] <PR Title>`
  - [x] Bug Fixes: PRs related to bug fixes should have in the title `[BugFix: Issue #X] <PR Title>`
  - [ ] Tech Debt: PRs related to technical debt should have in the title `[TechDebt: Issue #X] <PR Title>` 
  - [ ] New Release: PRs related to a new release should have in the title `[NewRelease] vX.Y.Z`

## Checklist for Admins
- [ ] Label is populated
- [ ] PR is assigned to the corresponding project
- [ ] PR has at least 1 reviewer and 1 assignee