### PR TITLE
[TechDebt] Usage docs update: envvar config option isn't available to other contexts (IDE extensions)

### DIFF
--- a/docs/using_openapi_provider.md
+++ b/docs/using_openapi_provider.md
@@ -9,7 +9,7 @@ different ways:
 ### OTF_VAR_<provider_name>_SWAGGER_URL
 
 Terraform will need to be executed passing in the OTF_VAR_<provider_name>_SWAGGER_URL environment variable pointing at the location
-where the swagger file is hosted, where````<your_provider_name>```` should be replaced with your provider's name.
+where the swagger file is hosted, where````<your_provider_name>```` should be replaced with your provider's name. Note that this variable will not be available to other contexts, like IDE extensions.
 
 ```
 $ terraform init && OTF_VAR_goa_SWAGGER_URL="https://some-domain-where-swagger-is-served.com/swagger.yaml" terraform plan


### PR DESCRIPTION
## What problem does this Pull Request solve?

The swagger URL environment variable `OTF_VAR_<provider_name>_SWAGGER_URL` isn't available in contexts like VSCode's Terraform extension, so language server features like autocomplete will fail. This was fairly difficult to diagnose and resolve.

## Type of change

What type of change does your code introduce to the provider? Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [ ] New feature (change that adds new functionality)
- [ ] Bug-fix (change that fixes current functionality)
- [x] Tech debt (enhances the current functionality)
- [ ] New release (pumps the version)

## Checklist

Please put an `x` (w/o heading/trailing white spaces) in the boxes that apply:

- [x] I have read and followed the [CONTRIBUTING](https://github.com/dikhan/terraform-provider-api/blob/master/.github/CONTRIBUTING.md) guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made sure code compiles correctly and all tests are passing by running `make test-all`
- [x] I have added/updated necessary documentation (if appropriate)
- [x] I have added the following info to the title of the PR (pick the appropriate option for the type of change). This is important because the release notes will include this information.
  - [ ] Feature Request: PRs related to feature requests should have in the title `[FeatureRequest: Issue #X] <PR Title>`
  - [ ] Bug Fixes: PRs related to bug fixes should have in the title `[BugFix: Issue #X] <PR Title>`
  - [x] Tech Debt: PRs related to technical debt should have in the title `[TechDebt: Issue #X] <PR Title>` 
  - [ ] New Release: PRs related to a new release should have in the title `[NewRelease] vX.Y.Z`